### PR TITLE
Mac support in net.cpp

### DIFF
--- a/src/net.cpp
+++ b/src/net.cpp
@@ -53,7 +53,11 @@ static bool vfReachable[NET_MAX] = {};
 static bool vfLimited[NET_MAX] = {};
 static CNode* pnodeLocalHost = NULL;
 uint64 nLocalHostNonce = 0;
+#ifdef MAC_OSX
+boost::array<int, THREAD_MAX> vnThreadsRunning;
+#else
 array<int, THREAD_MAX> vnThreadsRunning;
+#endif
 static std::vector<SOCKET> vhListenSocket;
 CAddrMan addrman;
 


### PR DESCRIPTION
Compiler conditional to use boost for the threads array on a mac.
