### PR TITLE
Fix for tray Icon.

### DIFF
--- a/src/qt/bitcoin.qrc
+++ b/src/qt/bitcoin.qrc
@@ -38,8 +38,8 @@
         <file alias="filesave">res/icons/filesave.png</file>
         <file>res/icons/horizontal_trans-no-shadow.png</file>
         <file>res/icons/paycoin_testnet.png</file>
-        <file>res/icons/paycoin.png</file>
-        <file alias="paycoin_tooltip">res/icons/paycoin.ico</file>
+        <file alias="paycoin_tooltip">res/icons/paycoin.png</file>
+        <file>res/icons/paycoin.ico</file>
     </qresource>
     <qresource prefix="/images">
         <file alias="about">res/images/about.png</file>


### PR DESCRIPTION
The ico file does not work on windows and linux platforms. Several users have reported to  be not working.
The png works.
