### PR TITLE
Update GitHub URLs to point to PaycoinFoundation/paycoin

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -17,7 +17,7 @@ Build-Depends: debhelper (>= 9.0.0),
  libqrencode-dev
 Standards-Version: 0.1.2.26
 Homepage: http://paycoin.com/
-Vcs-Git: https://github.com/GAWMiners/paycoin.git
+Vcs-Git: https://github.com/PaycoinFoundation/paycoin.git
 
 Package: paycoin-qt
 Architecture: any-amd64 any-i386 any-arm

--- a/debian/copyright
+++ b/debian/copyright
@@ -1,6 +1,6 @@
 Format: http://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
 Upstream-Name: paycoin
-Source: https://github.com/GAWMiners/paycoin.git
+Source: https://github.com/PaycoinFoundation/paycoin.git
 
 Files: *
 Copyright: Copyright (c) 2014 Paycoin (Paycoin) Developers

--- a/debian/watch
+++ b/debian/watch
@@ -1,3 +1,3 @@
 # Run the "uscan" command to check for upstream updates and more.
 version=3
-https://github.com/GAWMiners/paycoin/tags .*/v(\d[\d\.]*)\.tar\.gz
+https://github.com/PaycoinFoundation/paycoin/tags .*/v(\d[\d\.]*)\.tar\.gz

--- a/doc/build-osx-brew-mavericks.txt
+++ b/doc/build-osx-brew-mavericks.txt
@@ -72,7 +72,7 @@ sudo cp -r boost_1_55_0/boost/ /usr/include/boost/
 
 9.  Clone the github tree to get the source code
 
-git clone https://github.com/GAWMiners/paycoin.git
+git clone https://github.com/PaycoinFoundation/paycoin.git
 
 
 Building paycoind

--- a/doc/build-osx-brew.txt
+++ b/doc/build-osx-brew.txt
@@ -33,7 +33,7 @@ sudo ln -s /usr/local/lib /opt/local/lib/db48
 
 4.  Clone the github tree to get the source code
 
-git clone https://github.com/GAWMiners/paycoin.git
+git clone https://github.com/PaycoinFoundation/paycoin.git
 
 
 Building paycoind

--- a/doc/build-osx-ports-mavericks.txt
+++ b/doc/build-osx-ports-mavericks.txt
@@ -68,7 +68,7 @@ sudo cp -r boost_1_55_0/boost/ /usr/include/boost/
 
 9.  Clone the github tree to get the source code
 
-git clone https://github.com/GAWMiners/paycoin.git
+git clone https://github.com/PaycoinFoundation/paycoin.git
 
 
 Building paycoind

--- a/doc/build-osx-ports.txt
+++ b/doc/build-osx-ports.txt
@@ -29,7 +29,7 @@ sudo port install boost db48@+no_java openssl miniupnpc
 
 4.  Clone the github tree to get the source code
 
-git clone https://github.com/GAWMiners/paycoin.git
+git clone https://github.com/PaycoinFoundation/paycoin.git
 
 
 Building paycoind

--- a/doc/build-osx.txt
+++ b/doc/build-osx.txt
@@ -31,7 +31,7 @@ but you can get the current version from http://developer.apple.com
 
 1.  Clone the github tree to get the source code:
 
-git clone git@github.com/GAWMiners/paycoin.git paycoin
+git clone git@github.com/PaycoinFoundation/paycoin.git paycoin
 
 2.  Download and install MacPorts from http://www.macports.org/
 

--- a/share/setup.nsi
+++ b/share/setup.nsi
@@ -7,7 +7,7 @@ SetCompressor /SOLID lzma
 !define REGKEY "SOFTWARE\$(^Name)"
 !define VERSION 0.1.2.26
 !define COMPANY "Paycoin project"
-!define URL https://github.com/GAWMiners/paycoin/
+!define URL https://github.com/PaycoinFoundation/paycoin/
 
 # MUI Symbol Definitions
 !define MUI_ICON "../share/pixmaps/paycoin.ico"


### PR DESCRIPTION
Hopefully pretty simple. Just updating all the remaining GitHub URL references in the codebase to point to github.com/PaycoinFoundation/paycoin rather than github.com/GAWMiners/paycoin