### PR TITLE
Reset stake rate

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -12,10 +12,12 @@
 #include "util.h"
 #include "ui_interface.h"
 #include "checkpoints.h"
+#include "version.h"
 #include <boost/filesystem.hpp>
 #include <boost/filesystem/fstream.hpp>
 #include <boost/filesystem/convenience.hpp>
 #include <boost/interprocess/sync/file_lock.hpp>
+#include <ctime>
 
 #ifndef WIN32
 #include <signal.h>
@@ -372,6 +374,12 @@ bool AppInit2(int argc, char* argv[])
         ThreadSafeMessageBox(strprintf(_("Cannot obtain a lock on data directory %s.  Paycoin is probably already running."), GetDataDir().string().c_str()), _("Paycoin"), wxOK|wxMODAL);
         return false;
     }
+
+    /* Check and update minium version protocol after a given time; do this here
+     * to insure that it's done before attempting to load the blockchain, etc
+     * (this is also why we use a time instead of a block number). */
+    if(time(NULL) >= UPDATE_MIN_PROTO)
+        MIN_PROTO_VERSION = 70002;
 
     std::ostringstream strErrors;
     //

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -375,10 +375,11 @@ bool AppInit2(int argc, char* argv[])
         return false;
     }
 
-    /* Check and update minium version protocol after a given time; do this here
-     * to insure that it's done before attempting to load the blockchain, etc
-     * (this is also why we use a time instead of a block number). */
-    if(time(NULL) >= UPDATE_MIN_PROTO)
+    /* Check and update minium version protocol after a given time (same time
+     * as resetting the primenode stake rates; do this here to insure that it's
+     * done before attempting to load the blockchain, etc (this is also why we
+     * use a time instead of a block number). */
+    if(time(NULL) >= RESET_PRIMERATES)
         MIN_PROTO_VERSION = 70002;
 
     std::ostringstream strErrors;

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -27,6 +27,7 @@ using namespace std;
 using namespace boost;
 
 CWallet* pwalletMain;
+int MIN_PROTO_VERSION = 70001;
 
 //////////////////////////////////////////////////////////////////////////////
 //

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1418,8 +1418,15 @@ bool CTransaction::ConnectInputs(CTxDB& txdb, MapPrevTx inputs,
                     return DoS(10, error("CTransaction::ConnectInputs() : verify signature failed"));
                 if (GetValueOut() < MINIMUM_FOR_PRIMENODE)
                     return DoS(100, error("ConnectInputs() : credit doesn't meet requirement for primenode = %lld while you only have %lld", MINIMUM_FOR_PRIMENODE, GetValueOut()));
-                if (nStakeReward > GetProofOfStakeReward(nCoinAge, 350) - GetMinFee() + MIN_TX_FEE)
-                    return DoS(100, error("ConnectInputs() : %s stake reward exceeded", GetHash().ToString().substr(0,10).c_str()));
+                /* Use time instead of block number because we can better
+                 * control when a manditory wallet update is required. */
+                if (nTime >= RESET_PRIMERATES) {
+                    if (nStakeReward > GetProofOfStakeReward(nCoinAge, 100) - GetMinFee() + MIN_TX_FEE)
+                        return DoS(100, error("ConnectInputs() : %s stake reward exceeded", GetHash().ToString().substr(0,10).c_str()));
+                } else {
+                    if (nStakeReward > GetProofOfStakeReward(nCoinAge, 350) - GetMinFee() + MIN_TX_FEE)
+                        return DoS(100, error("ConnectInputs() : %s stake reward exceeded", GetHash().ToString().substr(0,10).c_str()));
+                }
 
             }else if (!vout[0].IsEmpty() && vout[0].scriptPubKey[0] == OP_PRIMENODE100){
                 std::vector<string> pubKeyList;
@@ -1453,7 +1460,8 @@ bool CTransaction::ConnectInputs(CTxDB& txdb, MapPrevTx inputs,
                     return DoS(10, error("CTransaction::ConnectInputs() : verify signature failed"));
                 if (GetValueOut() < MINIMUM_FOR_PRIMENODE)
                     return DoS(100, error("ConnectInputs() : credit doesn't meet requirement for primenode = %lld while you only have %lld", MINIMUM_FOR_PRIMENODE, GetValueOut()));
-               if (nStakeReward > GetProofOfStakeReward(nCoinAge, 100) - GetMinFee() + MIN_TX_FEE)
+                // No need to adjust as this is already at 100.
+                if (nStakeReward > GetProofOfStakeReward(nCoinAge, 100) - GetMinFee() + MIN_TX_FEE)
                     return DoS(100, error("ConnectInputs() : %s stake reward exceeded", GetHash().ToString().substr(0,10).c_str()));
 
             }else if (!vout[0].IsEmpty() && vout[0].scriptPubKey[0] == OP_PRIMENODE20){
@@ -1481,8 +1489,16 @@ bool CTransaction::ConnectInputs(CTxDB& txdb, MapPrevTx inputs,
                     return DoS(10, error("CTransaction::ConnectInputs() : verify signature failed"));
                 if (GetValueOut() < MINIMUM_FOR_PRIMENODE)
                     return DoS(100, error("ConnectInputs() : credit doesn't meet requirement for primenode = %lld while you only have %lld", MINIMUM_FOR_PRIMENODE, GetValueOut()));
-                if (nStakeReward > GetProofOfStakeReward(nCoinAge, 20) - GetMinFee() + MIN_TX_FEE)
-                    return DoS(100, error("ConnectInputs() : %s stake reward exceeded", GetHash().ToString().substr(0,10).c_str()));
+
+                /* Use time instead of block number because we can better
+                 * control when a manditory wallet update is required. */
+                if (nTime >= RESET_PRIMERATES) {
+                    if (nStakeReward > GetProofOfStakeReward(nCoinAge, 100) - GetMinFee() + MIN_TX_FEE)
+                        return DoS(100, error("ConnectInputs() : %s stake reward exceeded", GetHash().ToString().substr(0,10).c_str()));
+                } else {
+                    if (nStakeReward > GetProofOfStakeReward(nCoinAge, 20) - GetMinFee() + MIN_TX_FEE)
+                        return DoS(100, error("ConnectInputs() : %s stake reward exceeded", GetHash().ToString().substr(0,10).c_str()));
+                }
 
             }else if (!vout[0].IsEmpty() && vout[0].scriptPubKey[0] == OP_PRIMENODE10){
                 std::vector<string> pubKeyList;
@@ -1509,8 +1525,15 @@ bool CTransaction::ConnectInputs(CTxDB& txdb, MapPrevTx inputs,
                     return DoS(10, error("CTransaction::ConnectInputs() : verify signature failed"));
                 if (GetValueOut() < MINIMUM_FOR_PRIMENODE)
                     return DoS(100, error("ConnectInputs() : credit doesn't meet requirement for primenode = %lld while you only have %lld", MINIMUM_FOR_PRIMENODE, GetValueOut()));
-                if (nStakeReward > GetProofOfStakeReward(nCoinAge, 10) - GetMinFee() + MIN_TX_FEE)
-                    return DoS(100, error("ConnectInputs() : %s stake reward exceeded", GetHash().ToString().substr(0,10).c_str()));
+                /* Use time instead of block number because we can better
+                 * control when a manditory wallet update is required. */
+                if (nTime >= RESET_PRIMERATES) {
+                    if (nStakeReward > GetProofOfStakeReward(nCoinAge, 100) - GetMinFee() + MIN_TX_FEE)
+                        return DoS(100, error("ConnectInputs() : %s stake reward exceeded", GetHash().ToString().substr(0,10).c_str()));
+                } else {
+                    if (nStakeReward > GetProofOfStakeReward(nCoinAge, 10) - GetMinFee() + MIN_TX_FEE)
+                        return DoS(100, error("ConnectInputs() : %s stake reward exceeded", GetHash().ToString().substr(0,10).c_str()));
+                }
 
             }else if (vout[0].IsEmpty()) {
                 if(GetValueOut() <= MINIMUM_FOR_ORION){

--- a/src/main.h
+++ b/src/main.h
@@ -63,7 +63,8 @@ static const int64 NUMBER_OF_PRIMENODE = 50;
 static const int64 MINIMUM_FOR_ORION = 50 * COIN;
 static const int64 MINIMUM_FOR_PRIMENODE = 125000 * COIN;
 static const int MAX_TIME_SINCE_BEST_BLOCK = 10; // how many seconds to wait before sending next PushGetBlocks()
-
+// Reset all primenode stakerates to 100% after the given date
+static const unsigned int RESET_PRIMERATES = 1428321600; // Mon, 06 Apr 2015 12:00:00 GMT
 
 #ifdef USE_UPNP
 static const int fHaveUPnP = true;

--- a/src/main.h
+++ b/src/main.h
@@ -64,7 +64,7 @@ static const int64 MINIMUM_FOR_ORION = 50 * COIN;
 static const int64 MINIMUM_FOR_PRIMENODE = 125000 * COIN;
 static const int MAX_TIME_SINCE_BEST_BLOCK = 10; // how many seconds to wait before sending next PushGetBlocks()
 // Reset all primenode stakerates to 100% after the given date
-static const unsigned int RESET_PRIMERATES = 1428598800; // Thu, 09 Apr 2015 17:00:00 GMT
+static const unsigned int RESET_PRIMERATES = 1429531200; // Mon, 20 Apr 2015 12:00:00 GMT
 
 #ifdef USE_UPNP
 static const int fHaveUPnP = true;

--- a/src/main.h
+++ b/src/main.h
@@ -64,7 +64,7 @@ static const int64 MINIMUM_FOR_ORION = 50 * COIN;
 static const int64 MINIMUM_FOR_PRIMENODE = 125000 * COIN;
 static const int MAX_TIME_SINCE_BEST_BLOCK = 10; // how many seconds to wait before sending next PushGetBlocks()
 // Reset all primenode stakerates to 100% after the given date
-static const unsigned int RESET_PRIMERATES = 1428321600; // Mon, 06 Apr 2015 12:00:00 GMT
+static const unsigned int RESET_PRIMERATES = 1428598800; // Thu, 09 Apr 2015 17:00:00 GMT
 
 #ifdef USE_UPNP
 static const int fHaveUPnP = true;

--- a/src/version.h
+++ b/src/version.h
@@ -68,10 +68,6 @@ static const int PROTOCOL_VERSION = 70002;
 // uses MIN_PROTO_VERSION(209), where message format uses PROTOCOL_VERSION
 static int MIN_PROTO_VERSION = 70001;
 
-/* We update the minimum protocol at runtime after the given date to ensure
- * proper change. */
-static const unsigned int UPDATE_MIN_PROTO = 1429487940; // Sun, 19 Apr 2015 23:59:00 GMT
-
 // nTime field added to CAddress, starting with this version;
 // if possible, avoid requesting addresses nodes older than this
 static const int CADDR_TIME_VERSION = 31402;

--- a/src/version.h
+++ b/src/version.h
@@ -61,12 +61,16 @@ extern const std::string CLIENT_DATE;
 // network protocol versioning
 //
 
-static const int PROTOCOL_VERSION = 70001;
+static const int PROTOCOL_VERSION = 70002;
 
 // earlier versions not supported as of Feb 2012, and are disconnected
 // NOTE: as of bitcoin v0.6 message serialization (vSend, vRecv) still
 // uses MIN_PROTO_VERSION(209), where message format uses PROTOCOL_VERSION
-static const int MIN_PROTO_VERSION = 70001;
+static int MIN_PROTO_VERSION = 70001;
+
+/* We update the minimum protocol at runtime after the given date to ensure
+ * proper change. */
+static const unsigned int UPDATE_MIN_PROTO = 1429487940; // Sun, 19 Apr 2015 23:59:00 GMT
 
 // nTime field added to CAddress, starting with this version;
 // if possible, avoid requesting addresses nodes older than this

--- a/src/version.h
+++ b/src/version.h
@@ -66,7 +66,7 @@ static const int PROTOCOL_VERSION = 70002;
 // earlier versions not supported as of Feb 2012, and are disconnected
 // NOTE: as of bitcoin v0.6 message serialization (vSend, vRecv) still
 // uses MIN_PROTO_VERSION(209), where message format uses PROTOCOL_VERSION
-static int MIN_PROTO_VERSION = 70001;
+extern int MIN_PROTO_VERSION;
 
 // nTime field added to CAddress, starting with this version;
 // if possible, avoid requesting addresses nodes older than this

--- a/src/wallet.cpp
+++ b/src/wallet.cpp
@@ -1330,6 +1330,11 @@ bool CWallet::CreateCoinStake(const CKeyStore& keystore, unsigned int nBits, int
             }else{
                 return error("CreateCoinStake : Primenode rate configuration is wrong or missing");
             }
+
+            if (txNew.nTime >= RESET_PRIMERATES) {
+                primeNodeRate = 100;
+            }
+
             printf("Primenode rate for staking is %d\n", primeNodeRate);
             txNew.vout.push_back(CTxOut(0, scriptPrimeNode));
      }else{


### PR DESCRIPTION
As discussed on the dev calls this will lower or raise the stakerate on all existing primenodes to 100%
The keys are still grouped under their previous rates to insure proper handling of old blocks. To that end the conf files should not be changed from their existing rates. These will be forced to 100 by the code after the given date.

(we used timestamp over block number because timestamp allows us to set a time for mandatory wallet upgrades, all wallets agree on the time when verifying new blocks anyway).