### PR TITLE
Make rpcdump commands more informative with wallets unlocked for minting

### DIFF
--- a/src/rpcdump.cpp
+++ b/src/rpcdump.cpp
@@ -59,7 +59,7 @@ Value importprivkey(const Array& params, bool fHelp)
     if (pwalletMain->IsLocked())
         throw JSONRPCError(-13, "Error: Please enter the wallet passphrase with walletpassphrase first.");
     if (fWalletUnlockMintOnly) // paycoin: no importprivkey in mint-only mode
-        throw JSONRPCError(-102, "Wallet is unlocked for minting only.");
+        throw JSONRPCError(-102, "Wallet is unlocked for minting only (unlock with walletpassphrase).");
 
     CKey key;
     bool fCompressed;
@@ -98,7 +98,7 @@ Value dumpprivkey(const Array& params, bool fHelp)
     if (pwalletMain->IsLocked())
         throw JSONRPCError(-13, "Error: Please enter the wallet passphrase with walletpassphrase first.");
     if (fWalletUnlockMintOnly) // paycoin: no dumpprivkey in mint-only mode
-        throw JSONRPCError(-102, "Wallet is unlocked for minting only.");
+        throw JSONRPCError(-102, "Wallet is unlocked for minting only (unlock with walletpassphrase).");
     CKeyID keyID;
     if (!address.GetKeyID(keyID))
         throw JSONRPCError(-3, "Address does not refer to a key");


### PR DESCRIPTION
Update importprivkey and dumpprivkey to be more informative in the event the
wallet is encrypted but unlocked for minting (currently it does not inform
users of how to fully unlock their wallet if it is unlocked for minting only).