### PR TITLE
Revert "Disable compound staking on primenodes."

### DIFF
--- a/src/wallet.cpp
+++ b/src/wallet.cpp
@@ -1361,12 +1361,6 @@ bool CWallet::CreateCoinStake(const CKeyStore& keystore, unsigned int nBits, int
     int64 nReserveBalance = 0;
     if (mapArgs.count("-reservebalance") && !ParseMoney(mapArgs["-reservebalance"], nReserveBalance))
         return error("CreateCoinStake : invalid reserve balance amount");
-
-    // Force reserve on amounts over primenode minimum to block compound staking
-    if(nBalance > MINIMUM_FOR_PRIMENODE && primeNodeRate > 0) {
-        nReserveBalance = nBalance - MINIMUM_FOR_PRIMENODE;
-    }
-
     printf("Your balance is %lld and reservebalance is %lld\n", nBalance, nReserveBalance);
     if (nBalance <= nReserveBalance)
         return false;


### PR DESCRIPTION
Reverts PaycoinFoundation/paycoin#93

This sets the reserve properly but it would appear we can't use the reserve in this manner. Even though I'm sure it would still stake eventually setting the reserve this way causes primes to stall; presumably because the coins on reserve are part of the same transaction as the ones that the wallet is attempting to stake.

Revert this and we'll have to find a better way to block compound staking.