### PR TITLE
Small passphrasedialog update

### DIFF
--- a/src/qt/askpassphrasedialog.cpp
+++ b/src/qt/askpassphrasedialog.cpp
@@ -25,7 +25,6 @@ AskPassphraseDialog::AskPassphraseDialog(Mode mode, QWidget *parent) :
     ui->passEdit1->installEventFilter(this);
     ui->passEdit2->installEventFilter(this);
     ui->passEdit3->installEventFilter(this);
-    ui->capsLabel->clear();
 
     //Setup Keyboard
     keyboard = new VirtualKeyboard(this);

--- a/src/qt/forms/askpassphrasedialog.ui
+++ b/src/qt/forms/askpassphrasedialog.ui
@@ -23,7 +23,7 @@
    </size>
   </property>
   <property name="windowTitle">
-   <string>Dialog</string>
+   <string>Passphrase Dialog</string>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>
@@ -85,13 +85,14 @@
      </item>
      <item row="4" column="1">
       <widget class="QLabel" name="capsLabel">
-       <property name="styleSheet">
-        <string notr="true">#capsLabel {
-	font: bold;
-}</string>
+       <property name="font">
+        <font>
+         <weight>75</weight>
+         <bold>true</bold>
+        </font>
        </property>
        <property name="text">
-        <string>TextLabel</string>
+        <string/>
        </property>
        <property name="alignment">
         <set>Qt::AlignCenter</set>


### PR DESCRIPTION
- change dialog title to "Passphrase Dialog" as that's better for distinction on Transifex (still working on Transifex support but it's coming!)
- remove style-sheet for bold font and use default Qt Designer option for bold
- remove capsLabel default text -> results in removal of a clear() in the source