### PR TITLE
Rename qrcodedialog.ui window title to "QR Code Dialog" and change window size to the minimum values allowed by Qt Creator

### DIFF
--- a/src/qt/forms/qrcodedialog.ui
+++ b/src/qt/forms/qrcodedialog.ui
@@ -6,12 +6,12 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>379</width>
-    <height>441</height>
+    <width>334</width>
+    <height>425</height>
    </rect>
   </property>
   <property name="windowTitle">
-   <string>Dialog</string>
+   <string>QR Code Dialog</string>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout_3">
    <item>


### PR DESCRIPTION
When we implement Transifex this will make things easier as currently we have two sources for just the word "Dialog" to translate there.

- Changed window size to the minimum values allowed by Qt Creator