### PR TITLE
remove pre-paycoin protocol versions

### DIFF
--- a/src/db.cpp
+++ b/src/db.cpp
@@ -520,16 +520,6 @@ bool CTxDB::WriteCheckpointPubKey(const string& strPubKey)
     return Write(string("strCheckpointPubKey"), strPubKey);
 }
 
-bool CTxDB::ReadV04UpgradeTime(unsigned int& nUpgradeTime)
-{
-    return Read(string("nProtocolV04UpgradeTime"), nUpgradeTime);
-}
-
-bool CTxDB::WriteV04UpgradeTime(const unsigned int& nUpgradeTime)
-{
-    return Write(string("nProtocolV04UpgradeTime"), nUpgradeTime);
-}
-
 CBlockIndex static * InsertBlockIndex(uint256 hash)
 {
     if (hash == 0)

--- a/src/db.h
+++ b/src/db.h
@@ -301,8 +301,6 @@ public:
     bool WriteSyncCheckpoint(uint256 hashCheckpoint);
     bool ReadCheckpointPubKey(std::string& strPubKey);
     bool WriteCheckpointPubKey(const std::string& strPubKey);
-    bool ReadV04UpgradeTime(unsigned int& nUpgradeTime);
-    bool WriteV04UpgradeTime(const unsigned int& nUpgradeTime);
     bool LoadBlockIndex();
 };
 

--- a/src/kernel.h
+++ b/src/kernel.h
@@ -14,17 +14,6 @@ extern unsigned int nModifierInterval;
 // ratio of group interval length between the last group and the first group
 static const int MODIFIER_INTERVAL_RATIO = 3;
 
-// Protocol switch time of v0.3 kernel protocol
-extern unsigned int nProtocolV03SwitchTime;
-extern unsigned int nProtocolV03TestSwitchTime;
-// TxDB upgrade time for v0.4 protocol
-extern unsigned int nProtocolV04UpgradeTime;
-
-// Whether a given coinstake is subject to new v0.3 protocol
-bool IsProtocolV03(unsigned int nTimeCoinStake);
-// Whether a given block is subject to new v0.4 protocol
-bool IsProtocolV04(unsigned int nTimeBlock);
-
 // Compute the hash modifier for proof-of-stake
 bool ComputeNextStakeModifier(const CBlockIndex* pindexCurrent, uint64& nStakeModifier, bool& fGeneratedStakeModifier);
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2350,23 +2350,9 @@ bool CBlock::CheckBlockSignature() const
 unsigned int CBlock::GetStakeEntropyBit() const
 {
     unsigned int nEntropyBit = 0;
-    if (IsProtocolV04(nTime))
-    {
-        nEntropyBit = ((GetHash().Get64()) & 1llu);// last bit of block hash
-        if (fDebug && GetBoolArg("-printstakemodifier"))
-            printf("GetStakeEntropyBit(v0.4+): nTime=%u hashBlock=%s entropybit=%d\n", nTime, GetHash().ToString().c_str(), nEntropyBit);
-    }
-    else
-    {
-        // old protocol for entropy bit pre v0.4
-        uint160 hashSig = Hash160(vchBlockSig);
-        if (fDebug && GetBoolArg("-printstakemodifier"))
-            printf("GetStakeEntropyBit(v0.3): nTime=%u hashSig=%s", nTime, hashSig.ToString().c_str());
-        hashSig >>= 159; // take the first bit of the hash
-        nEntropyBit = hashSig.Get64();
-        if (fDebug && GetBoolArg("-printstakemodifier"))
-            printf(" entropybit=%d\n", nEntropyBit);
-    }
+    nEntropyBit = ((GetHash().Get64()) & 1llu);// last bit of block hash
+    if (fDebug && GetBoolArg("-printstakemodifier"))
+        printf("GetStakeEntropyBit(v0.4+): nTime=%u hashBlock=%s entropybit=%d\n", nTime, GetHash().ToString().c_str(), nEntropyBit);
     return nEntropyBit;
 }
 
@@ -2508,15 +2494,6 @@ bool LoadBlockIndex(bool fAllowNew)
         // paycoin: initialize synchronized checkpoint
         if (!Checkpoints::WriteSyncCheckpoint(hashGenesisBlock))
             return error("LoadBlockIndex() : failed to init sync checkpoint");
-
-        // paycoin: upgrade time set to zero if txdb initialized
-        {
-            CTxDB txdb;
-            if (!txdb.WriteV04UpgradeTime(0))
-                return error("LoadBlockIndex() : failed to init upgrade info");
-            printf(" Upgrade Info: v0.4+ txdb initialization\n");
-            txdb.Close();
-        }
     }
 
     // paycoin: if checkpoint master key changed must reset sync-checkpoint
@@ -2533,26 +2510,6 @@ bool LoadBlockIndex(bool fAllowNew)
                 return error("LoadBlockIndex() : failed to commit new checkpoint master key to db");
             if ((!fTestNet) && !Checkpoints::ResetSyncCheckpoint())
                 return error("LoadBlockIndex() : failed to reset sync-checkpoint");
-        }
-        txdb.Close();
-    }
-
-    // paycoin: upgrade time set to zero if txdb initialized
-    {
-        CTxDB txdb;
-        if (txdb.ReadV04UpgradeTime(nProtocolV04UpgradeTime))
-        {
-            if (nProtocolV04UpgradeTime)
-                printf(" Upgrade Info: txdb upgrade to v0.4 detected at timestamp %d\n", nProtocolV04UpgradeTime);
-            else
-                printf(" Upgrade Info: v0.4+ no txdb upgrade detected.\n");
-        }
-        else
-        {
-            nProtocolV04UpgradeTime = GetTime();
-            printf(" Upgrade Info: upgrading txdb from v0.3 at timestamp %u\n", nProtocolV04UpgradeTime);
-            if (!txdb.WriteV04UpgradeTime(nProtocolV04UpgradeTime))
-                return error("LoadBlockIndex() : failed to write upgrade info");
         }
         txdb.Close();
     }
@@ -2683,14 +2640,6 @@ string GetWarnings(string strFor)
     {
         nPriority = 3000;
         strStatusBar = strRPC = "WARNING: Invalid checkpoint found! Displayed transactions may not be correct! You may need to upgrade, or notify developers of the issue.";
-    }
-
-    // paycoin: if detected unmet upgrade requirement enter safe mode
-    // Note: v0.4 upgrade requires blockchain redownload if past protocol switch
-    if (IsProtocolV04(nProtocolV04UpgradeTime + 60*60*24)) // 1 day margin
-    {
-        nPriority = 5000;
-        strStatusBar = strRPC = "WARNING: Blockchain redownload required approaching or past v0.4 upgrade deadline.";
     }
 
     // Alerts


### PR DESCRIPTION
Do NOT merge at this time : discuss

Peercoin had several proof of stake protocol versions that have never been active in Paycoin, this would remove those otherwise dead versions and their accompanied code.

We did this awhile back and I've been playing with it off and on. So far the only issue I've noticed is downgrading on a wallet that was synced using a binary with this code will cause a warning to appear in regards to it being past the upgrade time.

I consider this to be a code cleanup and would like others to test it and comment.