### PR TITLE
Silence useless warning in src/json/json_spirit_writer_template.h to make important warnings easier to see.

### DIFF
--- a/src/json/json_spirit_writer_template.h
+++ b/src/json/json_spirit_writer_template.h
@@ -28,7 +28,8 @@ namespace json_spirit
     template< class String_type >
     String_type non_printable_to_string( unsigned int c )
     {
-        typedef typename String_type::value_type Char_type;
+        // Silence the warning: typedef ‘Char_type’ locally defined but not used [-Wunused-local-typedefs]
+        // typedef typename String_type::value_type Char_type;
 
         String_type result( 6, '\\' );
 


### PR DESCRIPTION
warning: typedef ‘Char_type’ locally defined but not used [-Wunused-local-typedefs]

Reference: https://github.com/bitcoin/bitcoin/commit/a6b3de139554574075008546e725d1ea604b266f