### PR TITLE
Fix minimum for primenodes to allow syncing the old primestakes

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1409,7 +1409,9 @@ bool CTransaction::ConnectInputs(CTxDB& txdb, MapPrevTx inputs,
                     }
                     if(!isVerify)
                         return DoS(10, error("CTransaction::ConnectInputs() : verify signature failed"));
-                    if (GetValueOut() < MINIMUM_FOR_PRIMENODE)
+                    if (nTime >= END_PRIME_PHASE_ONE && GetValueOut() < MINIMUM_FOR_PRIMENODE)
+                        return DoS(100, error("ConnectInputs() : credit doesn't meet requirement for primenode = %lld while you only have %lld", MINIMUM_FOR_PRIMENODE, GetValueOut()));
+                    if (GetValueOut() < MINIMUM_FOR_PRIMENODE_OLD)
                         return DoS(100, error("ConnectInputs() : credit doesn't meet requirement for primenode = %lld while you only have %lld", MINIMUM_FOR_PRIMENODE, GetValueOut()));
                     /* Use time instead of block number because we can better
                      * control when a manditory wallet update is required. */

--- a/src/main.h
+++ b/src/main.h
@@ -62,6 +62,7 @@ static const unsigned int MODIFIER_INTERVAL = 10 * 60;
 static const int64 NUMBER_OF_PRIMENODE = 50;
 static const int64 MINIMUM_FOR_ORION = 50 * COIN;
 static const int64 MINIMUM_FOR_PRIMENODE = 160000 * COIN;
+static const int64 MINIMUM_FOR_PRIMENODE_OLD = 125000 * COIN;
 static const int MAX_TIME_SINCE_BEST_BLOCK = 10; // how many seconds to wait before sending next PushGetBlocks()
 // Reset all primenode stakerates to 100% after the given date
 static const unsigned int RESET_PRIMERATES = 1429531200; // Mon, 20 Apr 2015 12:00:00 GMT


### PR DESCRIPTION
Currently syncing a new wallet fails when reaching the first prime stake from the original primenodes because it's minimum is below the defined value.

This will use the new value only if the nTime is after the end of phase one when running ConnectInputs.