### PR TITLE
Allow Qt to wrap long tooltips

### DIFF
--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -1,12 +1,14 @@
 /*
  * W.J. van der Laan 2011-2012
- * The Paycoin Developers 2013
+ * The PPCoin Developers 2013
+ * The Paycoin Developers 2014-2015
  */
 #include "bitcoingui.h"
 #include "clientmodel.h"
 #include "walletmodel.h"
 #include "optionsmodel.h"
 #include "guiutil.h"
+#include "guiconstants.h"
 
 #include "init.h"
 #include "ui_interface.h"
@@ -164,6 +166,9 @@ int main(int argc, char *argv[])
 
     Q_INIT_RESOURCE(bitcoin);
     QApplication app(argc, argv);
+
+    // Install global event filter that makes sure that long tooltips can be word-wrapped
+    app.installEventFilter(new GUIUtil::ToolTipToRichTextFilter(TOOLTIP_WRAP_THRESHOLD, &app));
 
     // Command-line options take precedence:
     ParseParameters(argc, argv);

--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -595,12 +595,12 @@ void BitcoinGUI::setNumBlocks(int count)
     // Set icon state: spinning if catching up, tick otherwise
     if(secs < 90*60 && count >= nTotalBlocks)
     {
-        tooltip = tr("Up to date") + QString(".\n") + tooltip;
+        tooltip = tr("Up to date") + QString(".<br>") + tooltip;
         labelBlocksIcon->setPixmap(QIcon(":/icons/synced").pixmap(STATUSBAR_ICONSIZE, STATUSBAR_ICONSIZE));
     }
     else
     {
-        tooltip = tr("Catching up...") + QString("\n") + tooltip;
+        tooltip = tr("Catching up...") + QString("<br>") + tooltip;
         labelBlocksIcon->setPixmap(QIcon(QString(
             ":/movies/spinner-%1").arg(spinnerFrame, 3, 10, QChar('0')))
             .pixmap(STATUSBAR_ICONSIZE, STATUSBAR_ICONSIZE));
@@ -609,9 +609,12 @@ void BitcoinGUI::setNumBlocks(int count)
 
     if(!text.isEmpty())
     {
-        tooltip += QString("\n");
+        tooltip += QString("<br>");
         tooltip += tr("Last received block was generated %1.").arg(text);
     }
+
+    // Don't word-wrap this (fixed-width) tooltip
+    tooltip = QString("<nobr>") + tooltip + QString("</nobr>");
 
     labelBlocksIcon->setToolTip(tooltip);
     progressBarLabel->setToolTip(tooltip);

--- a/src/qt/guiconstants.h
+++ b/src/qt/guiconstants.h
@@ -25,6 +25,11 @@ static const int STATUSBAR_ICONSIZE = 16;
 #define COLOR_MINT_MATURE QColor(127, 240, 127)
 #define COLOR_MINT_OLD QColor(240, 127, 127)
 
+/* Tooltips longer than this (in characters) are converted into rich text,
+   so that they can be word-wrapped.
+ */
+static const int TOOLTIP_WRAP_THRESHOLD = 80;
+
 /* Number of frames in spinner animation */
 #define SPINNER_FRAMES 35
 

--- a/src/qt/guiutil.cpp
+++ b/src/qt/guiutil.cpp
@@ -214,5 +214,28 @@ bool isObscured(QWidget *w)
            && checkPoint(QPoint(w->width()/2, w->height()/2), w));
 }
 
-} // namespace GUIUtil
+ToolTipToRichTextFilter::ToolTipToRichTextFilter(int size_threshold, QObject *parent):
+    size_threshold(size_threshold), QObject(parent)
+{
 
+}
+
+bool ToolTipToRichTextFilter::eventFilter(QObject *obj, QEvent *evt)
+{
+    if(evt->type() == QEvent::ToolTipChange)
+    {
+        QWidget *widget = static_cast<QWidget*>(obj);
+        QString tooltip = widget->toolTip();
+        if(!Qt::mightBeRichText(tooltip) && tooltip.size() > size_threshold)
+        {
+            // Prefix <qt/> to make sure Qt detects this as rich text
+            // Escape the current message as HTML and replace \n by <br>
+            tooltip = "<qt/>" + HtmlEscape(tooltip, true);
+            widget->setToolTip(tooltip);
+            return true;
+        }
+    }
+    return QObject::eventFilter(obj, evt);
+}
+
+} // namespace GUIUtil

--- a/src/qt/guiutil.h
+++ b/src/qt/guiutil.h
@@ -2,6 +2,7 @@
 #define GUIUTIL_H
 
 #include <QString>
+#include <QObject>
 
 QT_BEGIN_NAMESPACE
 class QFont;
@@ -68,6 +69,23 @@ namespace GUIUtil
 
     // Determine whether a widget is hidden behind other windows
     bool isObscured(QWidget *w);
+
+    /** Qt event filter that intercepts ToolTipChange events, and replaces the tooltip with a rich text
+      representation if needed. This assures that Qt can word-wrap long tooltip messages.
+      Tooltips longer than the provided size threshold (in characters) are wrapped.
+     */
+    class ToolTipToRichTextFilter: public QObject
+    {
+        Q_OBJECT
+    public:
+        ToolTipToRichTextFilter(int size_threshold, QObject *parent);
+
+    protected:
+        bool eventFilter(QObject *obj, QEvent *evt);
+
+    private:
+        int size_threshold;
+    };
 
 } // namespace GUIUtil
 


### PR DESCRIPTION
Allow Qt to word-wrap tooltips. Qt can only word-wrap rich text messages.

Implemented without having to touch any translation: by listening for QEvent::ToolTipChange events, then rewriting the tooltips to prefix <qt/> and convert to rich text if it is not yet rich text.

No wrap: https://dl.dropboxusercontent.com/u/37902134/Paycoin%20Core/No%20wrap.png
With wrap: https://dl.dropboxusercontent.com/u/37902134/Paycoin%20Core/With%20wrap.png