### PR TITLE
Win32: use _strnicmp (ISO C++) instead of deprecated strnicmp (POSIX)

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -21,6 +21,8 @@
 
 #ifndef WIN32
 #include <signal.h>
+#else
+#define strncasecmp _strnicmp
 #endif
 
 using namespace std;

--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -33,6 +33,10 @@ Q_IMPORT_PLUGIN(qkrcodecs)
 Q_IMPORT_PLUGIN(qtaccessiblewidgets)
 #endif
 
+#ifdef WIN32
+#define strncasecmp _strnicmp
+#endif
+
 // Need a global reference for the notifications to find the GUI
 static BitcoinGUI *guiref;
 static SplashScreen *splashref;
@@ -129,9 +133,6 @@ static void handleRunawayException(std::exception *e)
     exit(1);
 }
 
-#ifdef WIN32
-#define strncasecmp strnicmp
-#endif
 #ifndef BITCOIN_QT_TEST
 int main(int argc, char *argv[])
 {


### PR DESCRIPTION
- the #ifdef WIN32 parts were moved to the top of the files as this is a place everyone looks from time to time
- add missing "#define strncasecmp _strnicmp" in init.cpp

See http://msdn.microsoft.com/en-us/library/ms235324%28v=vs.80%29.aspx for reference on _strnicmp.

Reference: https://github.com/bitcoin/bitcoin/commit/f4ac41806af5766199a7d526a7becbcb8a0f5ab3