### PR TITLE
Remove strncasecmp() + strnicmp() calls use boost::algorithm::istarts_with()

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -17,6 +17,7 @@
 #include <boost/filesystem/fstream.hpp>
 #include <boost/filesystem/convenience.hpp>
 #include <boost/interprocess/sync/file_lock.hpp>
+#include <boost/algorithm/string/predicate.hpp>
 #include <ctime>
 
 #ifndef WIN32
@@ -315,7 +316,7 @@ bool AppInit2(int argc, char* argv[])
 
 #ifndef QT_GUI
     for (int i = 1; i < argc; i++)
-        if (!IsSwitchChar(argv[i][0]) && !(strlen(argv[i]) >= 7 && strncasecmp(argv[i], "paycoin:", 7) == 0))
+        if (!IsSwitchChar(argv[i][0]) && !boost::algorithm::istarts_with(argv[i], "paycoin:"))
             fCommandLine = true;
 
     if (fCommandLine)

--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -23,6 +23,7 @@
 #include <QLibraryInfo>
 
 #include <boost/interprocess/ipc/message_queue.hpp>
+#include <boost/algorithm/string/predicate.hpp>
 
 #if defined(BITCOIN_NEED_QT_PLUGINS) && !defined(_BITCOIN_QT_PLUGINS_INCLUDED)
 #define _BITCOIN_QT_PLUGINS_INCLUDED
@@ -131,9 +132,6 @@ static void handleRunawayException(std::exception *e)
     exit(1);
 }
 
-#ifdef WIN32
-#define strncasecmp strnicmp
-#endif
 #ifndef BITCOIN_QT_TEST
 int main(int argc, char *argv[])
 {
@@ -143,7 +141,7 @@ int main(int argc, char *argv[])
     // Do this early as we don't want to bother initializing if we are just calling IPC
     for (int i = 1; i < argc; i++)
     {
-        if (strlen(argv[i]) >= 7 && strncasecmp(argv[i], "paycoin:", 7) == 0)
+        if (boost::algorithm::istarts_with(argv[i], "paycoin:"))
         {
             const char *strURI = argv[i];
             try {
@@ -264,17 +262,16 @@ int main(int argc, char *argv[])
                 {
                     window.show();
                 }
+#if !defined(MAC_OSX) && !defined(WIN32)
+// TODO: implement qtipcserver.cpp for Mac and Windows
 
                 // Place this here as guiref has to be defined if we don't want to lose URIs
                 ipcInit();
 
-#if !defined(MAC_OSX) && !defined(WIN32)
-// TODO: implement qtipcserver.cpp for Mac and Windows
-
                 // Check for URI in argv
                 for (int i = 1; i < argc; i++)
                 {
-                    if (strlen(argv[i]) >= 7 && strncasecmp(argv[i], "paycoin:", 7) == 0)
+                    if (boost::algorithm::istarts_with(argv[i], "paycoin:"))
                     {
                         const char *strURI = argv[i];
                         try {


### PR DESCRIPTION
- remove strncasecmp() + strnicmp() calls and replace that code via boost::algorithm::istarts_with()
- do not call ipcInit() on Mac and Windows as this is unneeded currently

Supersedes #152 

Reference: https://github.com/bitcoin/bitcoin/commit/00fb08158d8a3a0d00f9d0360f376782b42f7d02