### PR TITLE
Remove autocorrection of 0/i in addresses in UI

### DIFF
--- a/src/qt/bitcoinaddressvalidator.cpp
+++ b/src/qt/bitcoinaddressvalidator.cpp
@@ -25,17 +25,11 @@ QValidator::State BitcoinAddressValidator::validate(QString &input, int &pos) co
     {
         bool removeChar = false;
         QChar ch = input.at(idx);
-        // Transform characters that are visually close
+        // Corrections made are very conservative on purpose, to avoid
+        // users unexpectedly getting away with typos that would normally
+        // be detected, and thus sending to the wrong address.
         switch(ch.unicode())
         {
-        case 'l':
-        case 'I':
-            input[idx] = QChar('1');
-            break;
-        case '0':
-        case 'O':
-            input[idx] = QChar('o');
-            break;
         // Qt categorizes these as "Other_Format" not "Separator_Space"
         case 0x200B: // ZERO WIDTH SPACE
         case 0xFEFF: // ZERO WIDTH NO-BREAK SPACE


### PR DESCRIPTION
I don't think we should autocorrect users because its not that unlikely to correct to the wrong thing and once coins are sent to a bogus address they are unrecoverable.

Users can no longer type O and 0 and such into the address field and it will only accept true base58 characters (and whitespaces, which are deleted).
