### PR TITLE
Prevent tooltip filter from ever causing infinite loops

### DIFF
--- a/src/qt/guiutil.cpp
+++ b/src/qt/guiutil.cpp
@@ -226,7 +226,7 @@ bool ToolTipToRichTextFilter::eventFilter(QObject *obj, QEvent *evt)
     {
         QWidget *widget = static_cast<QWidget*>(obj);
         QString tooltip = widget->toolTip();
-        if(!Qt::mightBeRichText(tooltip) && tooltip.size() > size_threshold)
+        if(tooltip.size() > size_threshold && !tooltip.startsWith("<qt/>") && !Qt::mightBeRichText(tooltip))
         {
             // Prefix <qt/> to make sure Qt detects this as rich text
             // Escape the current message as HTML and replace \n by <br>


### PR DESCRIPTION
I haven't seen this occur but I figured pull it in for good measure anyway (confirmed this builds on linux but I'd like to wait to merge it until I can test it in gitian which requires PR #165).