### PR TITLE
Fix invalid conversion error with MinGW 4.8.1 in net.cpp

### DIFF
--- a/src/net.cpp
+++ b/src/net.cpp
@@ -1742,7 +1742,11 @@ bool BindListenPort(const CService &addrBind, string& strError)
     // and enable it by default or not. Try to enable it, if possible.
     if (addrBind.IsIPv6()) {
 #ifdef IPV6_V6ONLY
+#ifdef WIN32
+        setsockopt(hListenSocket, IPPROTO_IPV6, IPV6_V6ONLY, (const char*)&nOne, sizeof(int));
+#else
         setsockopt(hListenSocket, IPPROTO_IPV6, IPV6_V6ONLY, (void*)&nOne, sizeof(int));
+#endif
 #endif
 #ifdef WIN32
         int nProtLevel = 10 /* PROTECTION_LEVEL_UNRESTRICTED */;


### PR DESCRIPTION
- fixes src\net.cpp:1601: Error:invalid conversion from 'void*' to 'const char*' [-fpermissive] in a setsockopt() call on Win32 that was found by using MinGW 4.8.1 compiler suite

See http://msdn.microsoft.com/en-us/library/windows/desktop/ms740476%28v=vs.85%29.aspx to verify that Win32 needs a `const char *`.