### PR TITLE
Windows: open debug.log file via Bitcoin-Qt

### DIFF
--- a/src/qt/forms/rpcconsole.ui
+++ b/src/qt/forms/rpcconsole.ui
@@ -7,11 +7,11 @@
     <x>0</x>
     <y>0</y>
     <width>706</width>
-    <height>446</height>
+    <height>382</height>
    </rect>
   </property>
   <property name="windowTitle">
-   <string>Paycoin (Paycoin) debug window</string>
+   <string>Paycoin debug window</string>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout_2">
    <item>
@@ -204,6 +204,42 @@
         </widget>
        </item>
        <item row="11" column="0">
+        <spacer name="verticalSpacer_2">
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>20</width>
+           <height>20</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+       <item row="12" column="0">
+        <widget class="QLabel" name="labelDebugLogfile">
+         <property name="font">
+          <font>
+           <weight>75</weight>
+           <bold>true</bold>
+          </font>
+         </property>
+         <property name="text">
+          <string>Debug logfile</string>
+         </property>
+        </widget>
+       </item>
+       <item row="13" column="0">
+        <widget class="QPushButton" name="openDebugLogfileButton">
+         <property name="toolTip">
+          <string>Open the Paycoin debug logfile from the current data directory. This can take a few seconds for large logfiles.</string>
+         </property>
+         <property name="text">
+          <string>&amp;Open</string>
+         </property>
+        </widget>
+       </item>
+       <item row="14" column="0">
         <spacer name="verticalSpacer">
          <property name="orientation">
           <enum>Qt::Vertical</enum>

--- a/src/qt/guiutil.cpp
+++ b/src/qt/guiutil.cpp
@@ -2,6 +2,7 @@
 #include "bitcoinaddressvalidator.h"
 #include "walletmodel.h"
 #include "bitcoinunits.h"
+#include "util.h"
 
 #include <QString>
 #include <QDateTime>
@@ -16,6 +17,26 @@
 #include <QFileDialog>
 #include <QDesktopServices>
 #include <QThread>
+
+#include <boost/filesystem.hpp>
+
+#ifdef WIN32
+#ifdef _WIN32_WINNT
+#undef _WIN32_WINNT
+#endif
+#define _WIN32_WINNT 0x0501
+#ifdef _WIN32_IE
+#undef _WIN32_IE
+#endif
+#define _WIN32_IE 0x0501
+#define WIN32_LEAN_AND_MEAN 1
+#ifndef NOMINMAX
+#define NOMINMAX
+#endif
+#include "shlwapi.h"
+#include "shlobj.h"
+#include "shellapi.h"
+#endif
 
 namespace GUIUtil {
 
@@ -212,6 +233,17 @@ bool isObscured(QWidget *w)
            && checkPoint(QPoint(0, w->height() - 1), w)
            && checkPoint(QPoint(w->width() - 1, w->height() - 1), w)
            && checkPoint(QPoint(w->width()/2, w->height()/2), w));
+}
+
+void openDebugLogfile()
+{
+    boost::filesystem::path pathDebug = GetDataDir() / "debug.log";
+
+#ifdef WIN32
+    if (boost::filesystem::exists(pathDebug))
+        /* Open debug.log with the associated application */
+        ShellExecuteA((HWND)0, (LPCSTR)"open", (LPCSTR)pathDebug.string().c_str(), NULL, NULL, SW_SHOWNORMAL);
+#endif
 }
 
 ToolTipToRichTextFilter::ToolTipToRichTextFilter(int size_threshold, QObject *parent):

--- a/src/qt/guiutil.h
+++ b/src/qt/guiutil.h
@@ -70,6 +70,9 @@ namespace GUIUtil
     // Determine whether a widget is hidden behind other windows
     bool isObscured(QWidget *w);
 
+    // Open debug.log
+    void openDebugLogfile();
+
     /** Qt event filter that intercepts ToolTipChange events, and replaces the tooltip with a rich text
       representation if needed. This assures that Qt can word-wrap long tooltip messages.
       Tooltips longer than the provided size threshold (in characters) are wrapped.

--- a/src/qt/rpcconsole.cpp
+++ b/src/qt/rpcconsole.cpp
@@ -190,11 +190,18 @@ RPCConsole::RPCConsole(QWidget *parent) :
 {
     ui->setupUi(this);
 
+#ifndef WIN32
+    // Show Debug logfile label and Open button only for Windows
+    ui->labelDebugLogfile->setVisible(false);
+    ui->openDebugLogfileButton->setVisible(false);
+#endif
+
     // Install event filter for up and down arrow
     ui->lineEdit->installEventFilter(this);
     ui->messagesWidget->installEventFilter(this);
 
     connect(ui->clearButton, SIGNAL(clicked()), this, SLOT(clear()));
+    connect(ui->openDebugLogfileButton, SIGNAL(clicked()), this, SLOT(on_openDebugLogfileButton_clicked()));
 
     startExecutor();
 
@@ -407,6 +414,11 @@ void RPCConsole::on_tabWidget_currentChanged(int index)
     {
         ui->lineEdit->setFocus();
     }
+}
+
+void RPCConsole::on_openDebugLogfileButton_clicked()
+{
+    GUIUtil::openDebugLogfile();
 }
 
 void RPCConsole::scrollToEnd()

--- a/src/qt/rpcconsole.h
+++ b/src/qt/rpcconsole.h
@@ -32,8 +32,8 @@ protected:
 
 private slots:
     void on_lineEdit_returnPressed();
-
     void on_tabWidget_currentChanged(int index);
+    void on_openDebugLogfileButton_clicked();
 
 public slots:
     void clear();


### PR DESCRIPTION
- This adds code to open (display) the debug.log on Windows with the associated application from the RPC console.
- Some small cleanups and tweaks.

Inspired by https://github.com/bitcoin/bitcoin/commit/4d3dda5d9f90d8aafb70c7e59beb27ec42d26790 but had to include a few other fixes. 

![](https://dl.dropboxusercontent.com/u/37902134/Paycoin%20Core/Open%20Debug.png)