### PR TITLE
Add icon for "About Qt" in menu

### DIFF
--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -269,7 +269,7 @@ void BitcoinGUI::createActions()
     aboutAction = new QAction(QIcon(":/icons/paycoin_tooltip"), tr("&About Paycoin"), this);
     aboutAction->setToolTip(tr("Show information about Paycoin"));
     aboutAction->setMenuRole(QAction::AboutRole);
-    aboutQtAction = new QAction(tr("About &Qt"), this);
+    aboutQtAction = new QAction(QIcon(":/trolltech/qmessagebox/images/qtlogo-64.png"), tr("About &Qt"), this);
     aboutQtAction->setToolTip(tr("Show information about Qt"));
     aboutQtAction->setMenuRole(QAction::AboutQtRole);
     optionsAction = new QAction(QIcon(":/icons/options"), tr("&Options..."), this);


### PR DESCRIPTION
It looks somewhat better to not have a missing icon.

Uses the built-in icon that is also used in the dialog box itself, so doesn't cost any extra space.

![](https://dl.dropboxusercontent.com/u/37902134/Paycoin%20Core/Qt%20Help%20Menu%20Icon.png)