### PR TITLE
Reopen log file on SIGHUP

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -101,6 +101,10 @@ void HandleSIGTERM(int)
     fRequestShutdown = true;
 }
 
+void HandleSIGHUP(int)
+{
+    fReopenDebugLog = true;
+}
 
 
 
@@ -186,7 +190,13 @@ bool AppInit2(int argc, char* argv[])
     sa.sa_flags = 0;
     sigaction(SIGTERM, &sa, NULL);
     sigaction(SIGINT, &sa, NULL);
-    sigaction(SIGHUP, &sa, NULL);
+
+    // Reopen debug.log on SIGHUP
+    struct sigaction sa_hup;
+    sa_hup.sa_handler = HandleSIGHUP;
+    sigemptyset(&sa_hup.sa_mask);
+    sa_hup.sa_flags = 0;
+    sigaction(SIGHUP, &sa_hup, NULL);
 #endif
 
     //

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -77,6 +77,7 @@ bool fTestNet = false;
 bool fNoListen = false;
 bool fLogTimestamps = false;
 CMedianFilter<int64> vTimeOffsets(200,0);
+bool fReopenDebugLog = false;
 
 // Init openssl library multithreading support
 static boost::interprocess::interprocess_mutex** ppmutexOpenSSL;
@@ -222,6 +223,14 @@ inline int OutputDebugStringF(const char* pszFormat, ...)
             static bool fStartedNewLine = true;
             static boost::mutex mutexDebugLog;
             boost::mutex::scoped_lock scoped_lock(mutexDebugLog);
+
+            // reopen the log file, if requested
+            if (fReopenDebugLog) {
+                fReopenDebugLog = false;
+                boost::filesystem::path pathDebug = GetDataDir() / "debug.log";
+                if (freopen(pathDebug.string().c_str(),"a",fileout) != NULL)
+                    setbuf(fileout, NULL); // unbuffered
+            }
 
             // Debug print useful for profiling
             if (fLogTimestamps && fStartedNewLine)

--- a/src/util.h
+++ b/src/util.h
@@ -134,6 +134,7 @@ extern std::string strMiscWarning;
 extern bool fTestNet;
 extern bool fNoListen;
 extern bool fLogTimestamps;
+extern bool fReopenDebugLog;
 
 void RandAddSeed();
 void RandAddSeedPerfmon();


### PR DESCRIPTION
This PR implements the features found on [pr 917](https://github.com/bitcoin/bitcoin/pull/917) from Bitcoin. It causes a SIGHUP signal to make the daemon reload the log file, to facilitate log rotation.

I have tested this with logrotate, and all seems to be working (where the normal daemon would get stuck not writing to the log file)

This can be useful in situations where the daemon will write a large log file. 