### PR TITLE
Fix Up to date QT-Status

### DIFF
--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -603,7 +603,7 @@ void BitcoinGUI::setNumBlocks(int count)
     }
 
     // Set icon state: spinning if catching up, tick otherwise
-    if(secs < 90*60 && count >= nTotalBlocks)
+    if(secs < 9*60 && count >= nTotalBlocks)
     {
         tooltip = tr("Up to date") + QString(".<br>") + tooltip;
         labelBlocksIcon->setPixmap(QIcon(":/icons/synced").pixmap(STATUSBAR_ICONSIZE, STATUSBAR_ICONSIZE));


### PR DESCRIPTION
The status in the QT client was using a Bitcoin value of 90 minutes.

This should be more realistic as in the Paycoin world blocks are much faster, and happen every minute.

Dividing the amount of blocks behind by 10 (Bitcoin block time) gets us 9 minutes, which I consider an appropriate amount of time to be behind on blocks for Paycoin, although this is up for discussion.