### PR TITLE
GUI fix: DebugLog file opens twice after clicking "Open" in RPC Console Information tab

### DIFF
--- a/src/qt/rpcconsole.cpp
+++ b/src/qt/rpcconsole.cpp
@@ -201,7 +201,6 @@ RPCConsole::RPCConsole(QWidget *parent) :
     ui->messagesWidget->installEventFilter(this);
 
     connect(ui->clearButton, SIGNAL(clicked()), this, SLOT(clear()));
-    connect(ui->openDebugLogfileButton, SIGNAL(clicked()), this, SLOT(on_openDebugLogfileButton_clicked()));
 
     startExecutor();
 


### PR DESCRIPTION
Sorry I picked up on this in my original commit #168 but at the time it wasn't very detrimental and I didn't have the fix so I let it go through.

But here's the fix :)