### PR TITLE
Minor update to makefiles.

### DIFF
--- a/src/makefile.linux-mingw
+++ b/src/makefile.linux-mingw
@@ -97,6 +97,6 @@ clean:
 	-rm -f paycoind.exe
 	-rm -f obj-test/*.o
 	-rm -f test_paycoin.exe
-	-rm -f src/build.h
+	-rm -f obj/build.h
 
 FORCE:

--- a/src/makefile.osx
+++ b/src/makefile.osx
@@ -152,6 +152,6 @@ clean:
 	-rm -f obj-test/*.o
 	-rm -f obj/*.P
 	-rm -f obj-test/*.P
-	-rm -f src/build.h
+	-rm -f obj/build.h
 
 FORCE:

--- a/src/makefile.osx-mavericks
+++ b/src/makefile.osx-mavericks
@@ -154,6 +154,6 @@ clean:
 	-rm -f obj-test/*.o
 	-rm -f obj/*.P
 	-rm -f obj-test/*.P
-	-rm -f src/build.h
+	-rm -f obj/build.h
 
 FORCE:

--- a/src/makefile.unix
+++ b/src/makefile.unix
@@ -154,6 +154,6 @@ clean:
 	-rm -f obj-test/*.o
 	-rm -f obj/*.P
 	-rm -f obj-test/*.P
-	-rm -f src/build.h
+	-rm -f obj/build.h
 
 FORCE:


### PR DESCRIPTION
This has absolutely no effect on a standard build since the build.h file in
src/obj always lists the date and time of the last tag qt generates a build.h
file in build/ with the correct (modified) version which is used when creating
the version displayed in the binary but it is only generated by the QT (meaning
the daemon is modifying the date/time a different way).

But as it stands we're removing a not existent file on `make clean`, so let's
remove the correct file.