### PR TITLE
P2P: Do not request blocks from peers with fewer blocks than us

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2858,6 +2858,7 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv)
         // Ask the first connected node for block updates
         static int nAskedForBlocks = 0;
         if (!pfrom->fClient && !pfrom->fOneShot &&
+            (pfrom->nStartingHeight > (nBestHeight - 144)) &&
             (pfrom->nVersion < NOBLKS_VERSION_START ||
              pfrom->nVersion >= NOBLKS_VERSION_END) &&
              (nAskedForBlocks < 1 || vNodes.size() <= 1))


### PR DESCRIPTION
If the remote node has a shorter chain, do not waste our
special getblocks request on them.