### PR TITLE
Make truncating the debug.log file an option.

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -281,6 +281,7 @@ bool AppInit2(int argc, char* argv[])
             "  -testnet         \t\t  " + _("Use the test network") + "\n" +
             "  -debug           \t\t  " + _("Output extra debugging information") + "\n" +
             "  -logtimestamps   \t  "   + _("Prepend debug output with timestamp") + "\n" +
+            "  -shrinkdebugfile       " + _("Shrink debug.log file on client startup (default: 1 when no -debug)") + "\n" +
             "  -printtoconsole  \t  "   + _("Send trace/debug info to console instead of debug.log file") + "\n" +
 #ifdef WIN32
             "  -printtodebugger \t  "   + _("Send trace/debug info to debugger") + "\n" +
@@ -377,7 +378,7 @@ bool AppInit2(int argc, char* argv[])
     }
 #endif
 
-    if (!fDebug)
+    if (GetBoolArg("-shrinkdebugfile", !fDebug))
         ShrinkDebugFile();
     printf("\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n");
     printf("Paycoin version %s (%s)\n", FormatFullVersion().c_str(), CLIENT_DATE.c_str());


### PR DESCRIPTION
Useful for developers who need to refer to futher back in debug.log history, but who don't want to
enable the -debug option and all the verbosity that comes with that.

This implements [1396](https://github.com/bitcoin/bitcoin/pull/1396)

