### PR TITLE
CHashWriter that does SHA256 in-place during serialization

### DIFF
--- a/src/util.h
+++ b/src/util.h
@@ -611,6 +611,46 @@ inline uint256 Hash(const T1 pbegin, const T1 pend)
     return hash2;
 }
 
+class CHashWriter
+{
+private:
+    SHA256_CTX ctx;
+
+public:
+    int nType;
+    int nVersion;
+
+    void Init() {
+        SHA256_Init(&ctx);
+    }
+
+    CHashWriter(int nTypeIn, int nVersionIn) : nType(nTypeIn), nVersion(nVersionIn) {
+        Init();
+    }
+
+    CHashWriter& write(const char *pch, size_t size) {
+        SHA256_Update(&ctx, pch, size);
+        return (*this);
+    }
+
+    // invalidates the object
+    uint256 GetHash() {
+        uint256 hash1;
+        SHA256_Final((unsigned char*)&hash1, &ctx);
+        uint256 hash2;
+        SHA256((unsigned char*)&hash1, sizeof(hash1), (unsigned char*)&hash2);
+        return hash2;
+    }
+
+    template<typename T>
+    CHashWriter& operator<<(const T& obj) {
+        // Serialize to this stream
+        ::Serialize(*this, obj, nType, nVersion);
+        return (*this);
+    }
+};
+
+
 template<typename T1, typename T2>
 inline uint256 Hash(const T1 p1begin, const T1 p1end,
                     const T2 p2begin, const T2 p2end)
@@ -648,13 +688,9 @@ inline uint256 Hash(const T1 p1begin, const T1 p1end,
 template<typename T>
 uint256 SerializeHash(const T& obj, int nType=SER_GETHASH, int nVersion=PROTOCOL_VERSION)
 {
-    // Most of the time is spent allocating and deallocating CDataStream's
-    // buffer.  If this ever needs to be optimized further, make a CStaticStream
-    // class with its buffer on the stack.
-    CDataStream ss(nType, nVersion);
-    ss.reserve(10000);
+    CHashWriter ss(nType, nVersion);
     ss << obj;
-    return Hash(ss.begin(), ss.end());
+    return ss.GetHash();
 }
 
 inline uint160 Hash160(const std::vector<unsigned char>& vch)


### PR DESCRIPTION
I confirmed this builds in gitian and used it to sync a chain as well as left it running on a testnet prime overnight, everything appears to be functioning properly (if anyone wants to test that's great of course).

I have not been able to test CPU load in comparison to without this function but based on the authors notes it seems viable.

Reference: https://github.com/bitcoin/bitcoin/pull/1567