### PR TITLE
Network burn addresses for mainnet and testnet

### DIFF
--- a/src/main.h
+++ b/src/main.h
@@ -732,7 +732,8 @@ public:
      */
     bool ConnectInputs(CTxDB& txdb, MapPrevTx inputs,
                        std::map<uint256, CTxIndex>& mapTestPool, const CDiskTxPos& posThisTx,
-                       const CBlockIndex* pindexBlock, bool fBlock, bool fMiner, bool fStrictPayToScriptHash=true);
+                       const CBlockIndex* pindexBlock, int64 &nBurnCoins, bool fBlock,
+                       bool fMiner, bool fStrictPayToScriptHash=true);
     bool ClientConnectInputs();
     bool CheckTransaction() const;
     bool AcceptToMemoryPool(CTxDB& txdb, bool fCheckInputs=true, bool* pfMissingInputs=NULL);

--- a/src/script.cpp
+++ b/src/script.cpp
@@ -132,6 +132,7 @@ const char* GetOpName(opcodetype opcode)
     case OP_ENDIF                  : return "OP_ENDIF";
     case OP_VERIFY                 : return "OP_VERIFY";
     case OP_RETURN                 : return "OP_RETURN";
+    case OP_BURN                   : return "OP_BURN";
 
     // stack ops
     case OP_TOALTSTACK             : return "OP_TOALTSTACK";

--- a/src/script.h
+++ b/src/script.h
@@ -199,6 +199,9 @@ enum opcodetype
     OP_PRIMENODEP2 = 0xc5,
     OP_MICROPRIME = 0xc6,
 
+    // extra control function
+    OP_BURN = 0xd0,
+
     // template matching params
     OP_SMALLINTEGER = 0xfa,
     OP_PUBKEYS = 0xfb,

--- a/src/wallet.h
+++ b/src/wallet.h
@@ -161,7 +161,7 @@ public:
     int64 GetUnconfirmedBalance() const;
     int64 GetStake() const;
     int64 GetNewMint() const;
-    bool CreateTransaction(const std::vector<std::pair<CScript, int64> >& vecSend, CWalletTx& wtxNew, CReserveKey& reservekey, int64& nFeeRet, const CCoinControl *coinControl=NULL);
+    bool CreateTransaction(std::vector<std::pair<CScript, int64> >& vecSend, CWalletTx& wtxNew, CReserveKey& reservekey, int64& nFeeRet, const CCoinControl *coinControl=NULL);
     bool CreateTransaction(CScript scriptPubKey, int64 nValue, CWalletTx& wtxNew, CReserveKey& reservekey, int64& nFeeRet, const CCoinControl *coinControl=NULL);
     bool CreateCoinStake(const CKeyStore& keystore, unsigned int nBits, int64 nSearchInterval, CTransaction& txNew, int64 nMoneySupply);
     bool CommitTransaction(CWalletTx& wtxNew, CReserveKey& reservekey);


### PR DESCRIPTION
DO NOT MERGE AT THIS TIME

"I don't want to set the world on fire...
I just want to start a flame in your heart."

Remove burnt coins from UTXO using OP_RETURN (set during CreateTransaction)
Mark with new OP code of OP_BURN to specify removing them from the money supply

Burn addresses provided are proveably unspendable addresses (this is not
necessary as any coins marked OP_RETURN are automatically unspendable; this is
done purely for appearance to avoid any debate over whether burnt coins are
retrievable).

Addresses are generated from the following public key (PI to 129 decimal places)
3141592653589793238462643383279502884197169399375105820974944592307816406286208998628034825342117067982148086513282306647093844609

These addresses can be generated by following standard steps for creating an
address, see below for relevant step results:

Mainnet:
extended RIPEMD160: 3784B371490B11657CD65B913C5693C218FE0F84F8
25 Byte Binary address: 3784B371490B11657CD65B913C5693C218FE0F84F85FED07E0
base 58 encoded address: PLgqKBNdyGJ4rC21efAQhDUsrZZRU4qcQo
Testnet:
extended RIPEMD160: 6F84B371490B11657CD65B913C5693C218FE0F84F8
25 Byte Binary address: 6F84B371490B11657CD65B913C5693C218FE0F84F8F874A9D9
base 58 encoded address: msccTG4mjNF8eTps29pFrEiw6ozFM5dwJ8

Do to the requirements to remove the coins from the total money supply this cannot be implemented until a protocol update is done. Hold off on merging this until we merge microprimes for the mainnet (as that will also require a protocol update/fork).