### PR TITLE
Enable suppressed unsigned warnings and fix offenders

### DIFF
--- a/paycoin.pro
+++ b/paycoin.pro
@@ -91,7 +91,7 @@ contains(BITCOIN_NEED_QT_PLUGINS, 1) {
     DEFINES += HAVE_BUILD_INFO
 }
 
-QMAKE_CXXFLAGS_WARN_ON = -Wall -Wextra -Wformat -Wformat-security -Wno-invalid-offsetof -Wno-sign-compare -Wno-unused-parameter
+QMAKE_CXXFLAGS_WARN_ON = -Wall -Wextra -Wformat -Wformat-security -Wno-invalid-offsetof -Wno-unused-parameter
 # this option unrecognized when building on OSX 10.6.8
 !macx {
     QMAKE_CXXFLAGS_WARN_ON += -fdiagnostics-show-option

--- a/src/addrman.cpp
+++ b/src/addrman.cpp
@@ -102,12 +102,11 @@ CAddrInfo* CAddrMan::Create(const CAddress &addr, const CNetAddr &addrSource, in
     return &mapInfo[nId];
 }
 
-void CAddrMan::SwapRandom(int nRndPos1, int nRndPos2)
+void CAddrMan::SwapRandom(unsigned int nRndPos1, unsigned int nRndPos2)
 {
     if (nRndPos1 == nRndPos2)
         return;
 
-    assert(nRndPos1 >= 0 && nRndPos2 >= 0);
     assert(nRndPos1 < vRandom.size() && nRndPos2 < vRandom.size());
 
     int nId1 = vRandom[nRndPos1];
@@ -149,7 +148,7 @@ int CAddrMan::SelectTried(int nKBucket)
 
 int CAddrMan::ShrinkNew(int nUBucket)
 {
-    assert(nUBucket >= 0 && nUBucket < vvNew.size());
+    assert(nUBucket >= 0 && (unsigned int)nUBucket < vvNew.size());
     std::set<int> &vNew = vvNew[nUBucket];
 
     // first look for deletable items

--- a/src/addrman.h
+++ b/src/addrman.h
@@ -204,7 +204,7 @@ protected:
     CAddrInfo* Create(const CAddress &addr, const CNetAddr &addrSource, int *pnId = NULL);
 
     // Swap two elements in vRandom.
-    void SwapRandom(int nRandomPos1, int nRandomPos2);
+    void SwapRandom(unsigned int nRandomPos1, unsigned int nRandomPos2);
 
     // Return position in given bucket to replace.
     int SelectTried(int nKBucket);

--- a/src/bignum.h
+++ b/src/bignum.h
@@ -194,7 +194,7 @@ public:
         if (vch.size() > 4)
             vch[4] &= 0x7f;
         uint64 n = 0;
-        for (int i = 0, j = vch.size()-1; i < sizeof(n) && j >= 4; i++, j--)
+        for (unsigned int i = 0, j = vch.size()-1; i < sizeof(n) && j >= 4; i++, j--)
             ((unsigned char*)&n)[i] = vch[j];
         return n;
     }

--- a/src/bitcoinrpc.cpp
+++ b/src/bitcoinrpc.cpp
@@ -878,7 +878,7 @@ Value listminting(const Array& params, bool fHelp)
                 "listminting [count=-1] [from=0]\n"
                 "Return all mintable outputs and provide details for each of them.");
 
-    int count = -1;
+    unsigned int count = -1;
 
     if(params.size() > 0)
         count = params[0].get_int();
@@ -2741,7 +2741,7 @@ Value gettxout(const Array& params, bool fHelp)
         if (mempool.exists(hash))
         {
             tx = mempool.lookup(hash);
-            if (n >= tx.vout.size())
+            if (n >= (int)tx.vout.size())
                 return Value::null;
             fFound = true;
             fInMempool = true;
@@ -2754,7 +2754,7 @@ Value gettxout(const Array& params, bool fHelp)
         CTxIndex txindex;
         if (!txdb.ReadTxIndex(hash, txindex))
             return Value::null;
-        if (n >= txindex.vSpent.size())
+        if (n >= (int)txindex.vSpent.size())
             return Value::null;
         if (!txindex.vSpent[n].IsNull())
             return Value::null;

--- a/src/compat.h
+++ b/src/compat.h
@@ -11,7 +11,10 @@
 #ifndef NOMINMAX
 #define NOMINMAX
 #endif
+#ifdef FD_SETSIZE
+#undef FD_SETSIZE
 #define FD_SETSIZE 1024 // max number of fds in fd_set
+#endif
 #include <winsock2.h>
 #include <mswsock.h>
 #include <ws2tcpip.h>

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -20,7 +20,6 @@
 #include <boost/filesystem/convenience.hpp>
 #include <boost/interprocess/sync/file_lock.hpp>
 #include <boost/algorithm/string/predicate.hpp>
-#include <ctime>
 #include <openssl/crypto.h>
 
 #ifndef WIN32

--- a/src/kernelrecord.cpp
+++ b/src/kernelrecord.cpp
@@ -36,7 +36,7 @@ vector<KernelRecord> KernelRecord::decomposeOutput(const CWallet *wallet, const 
 
     if (showTransaction(wtx))
     {
-        for (int nOut = 0; nOut < wtx.vout.size(); nOut++)
+        for (unsigned int nOut = 0; nOut < wtx.vout.size(); nOut++)
         {
             CTxOut txOut = wtx.vout[nOut];
             if( wallet->IsMine(txOut) ) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -464,7 +464,7 @@ bool CTransaction::CheckTransaction() const
 
     // Check for negative or overflow output values
     int64 nValueOut = 0;
-    for (int i = 0; i < vout.size(); i++)
+    for (unsigned int i = 0; i < vout.size(); i++)
     {
         const CTxOut& txout = vout[i];
         if (txout.IsEmpty() && (!IsCoinBase()) && (!IsCoinStake()))
@@ -2015,7 +2015,7 @@ bool CBlock::CheckBlock(int64 nHeight) const
             return DoS(100, error("CheckBlock() : more than one coinbase"));
 
     // paycoin: only the second transaction can be the optional coinstake
-    for (int i = 2; i < vtx.size(); i++)
+    for (unsigned int i = 2; i < vtx.size(); i++)
         if (vtx[i].IsCoinStake())
             return DoS(100, error("CheckBlock() : coinstake in wrong position"));
 
@@ -2356,7 +2356,7 @@ bool CheckDiskSpace(uint64 nAdditionalBytes)
 
 FILE* OpenBlockFile(unsigned int nFile, unsigned int nBlockPos, const char* pszMode)
 {
-    if (nFile == -1)
+    if (nFile == (unsigned int)-1)
         return NULL;
     FILE* file = fopen((GetDataDir() / strprintf("blk%04d.dat", nFile)).string().c_str(), pszMode);
     if (!file)
@@ -2385,7 +2385,7 @@ FILE* AppendBlockFile(unsigned int& nFileRet)
         if (fseek(file, 0, SEEK_END) != 0)
             return NULL;
         // FAT32 filesize max 4GB, fseek and ftell max 2GB, so we must stay under 2GB
-        if (ftell(file) < 0x7F000000 - MAX_SIZE)
+        if (ftell(file) < 0x7F000000 - (int)MAX_SIZE)
         {
             nFileRet = nCurrentBlockFile;
             return file;

--- a/src/main.h
+++ b/src/main.h
@@ -36,7 +36,7 @@ static const int64 MIN_TXOUT_AMOUNT = MIN_TX_FEE;
 inline bool MoneyRange(int64 nValue) { return (nValue >= 0 && nValue <= MAX_MONEY); }
 static const int COINBASE_MATURITY_PPC = 100;
 // Threshold for nLockTime: below this value it is interpreted as block number, otherwise as UNIX timestamp.
-static const int LOCKTIME_THRESHOLD = 500000000; // Tue Nov  5 00:53:20 1985 UTC
+static const unsigned int LOCKTIME_THRESHOLD = 500000000; // Tue Nov  5 00:53:20 1985 UTC
 static const int STAKE_TARGET_SPACING = 1 * 60; // 1-minute block
 static const int STAKE_MIN_AGE = 60 * 60; // minimum age for coin age
 static const int STAKE_MAX_AGE = 60 * 60 * 24 * 5; // stake age of full weight
@@ -167,7 +167,7 @@ public:
 
     IMPLEMENT_SERIALIZE( READWRITE(FLATDATA(*this)); )
     void SetNull() { nFile = -1; nBlockPos = 0; nTxPos = 0; }
-    bool IsNull() const { return (nFile == -1); }
+    bool IsNull() const { return (nFile == (unsigned int)-1); }
 
     friend bool operator==(const CDiskTxPos& a, const CDiskTxPos& b)
     {
@@ -207,7 +207,7 @@ public:
     CInPoint() { SetNull(); }
     CInPoint(CTransaction* ptxIn, unsigned int nIn) { ptx = ptxIn; n = nIn; }
     void SetNull() { ptx = NULL; n = -1; }
-    bool IsNull() const { return (ptx == NULL && n == -1); }
+    bool IsNull() const { return (ptx == NULL && n == (unsigned int)-1); }
 };
 
 
@@ -223,7 +223,7 @@ public:
     COutPoint(uint256 hashIn, unsigned int nIn) { hash = hashIn; n = nIn; }
     IMPLEMENT_SERIALIZE( READWRITE(FLATDATA(*this)); )
     void SetNull() { hash = 0; n = -1; }
-    bool IsNull() const { return (hash == 0 && n == -1); }
+    bool IsNull() const { return (hash == 0 && n == (unsigned int)-1); }
 
     friend bool operator<(const COutPoint& a, const COutPoint& b)
     {

--- a/src/makefile.linux-mingw
+++ b/src/makefile.linux-mingw
@@ -30,7 +30,8 @@ LIBS= \
 
 DEFS=-D_MT -DWIN32 -D_WINDOWS -DBOOST_THREAD_USE_LIB -DBOOST_SPIRIT_THREADSAFE -DUSE_IPV6
 DEBUGFLAGS=-g
-CFLAGS=-O2 -w -Wno-invalid-offsetof -Wformat $(DEBUGFLAGS) $(DEFS) $(INCLUDEPATHS)
+CFLAGS=-O2 -w -Wall -Wextra -Wno-unused-parameter -Wformat -Wformat-security \
+    $(DEBUGFLAGS) $(DEFS) $(INCLUDEPATHS)
 
 TESTDEFS = -DTEST_DATA_DIR=$(abspath test/data)
 

--- a/src/makefile.osx
+++ b/src/makefile.osx
@@ -76,7 +76,7 @@ CFLAGS = -g
 endif
 
 # ppc doesn't work because we don't support big-endian
-CFLAGS += -Wextra -Wno-sign-compare -Wno-invalid-offsetof -Wformat-security \
+CFLAGS += -Wextra -Wno-invalid-offsetof -Wformat-security \
     $(DEBUGFLAGS) $(DEFS) $(INCLUDEPATHS)
 
 OBJS= \

--- a/src/makefile.osx-mavericks
+++ b/src/makefile.osx-mavericks
@@ -77,7 +77,7 @@ CFLAGS = -g
 endif
 
 # ppc doesn't work because we don't support big-endian
-CFLAGS += -w -Wextra -Wno-sign-compare -Wno-invalid-offsetof -Wformat-security \
+CFLAGS += -w -Wextra -Wno-invalid-offsetof -Wformat-security \
     $(DEBUGFLAGS) $(DEFS) $(INCLUDEPATHS)
 
 OBJS= \

--- a/src/makefile.unix
+++ b/src/makefile.unix
@@ -86,7 +86,7 @@ LIBS+= \
 
 DEBUGFLAGS=-g
 CXXFLAGS=-O2
-xCXXFLAGS=-pthread -Wall -Wextra -Wno-sign-compare -Wno-invalid-offsetof -Wno-unused-parameter -Wformat -Wformat-security \
+xCXXFLAGS=-pthread -Wall -Wextra -Wno-unused-parameter -Wformat -Wformat-security \
     $(DEBUGFLAGS) $(DEFS) $(HARDENING) $(CXXFLAGS)
 
 OBJS= \

--- a/src/net.h
+++ b/src/net.h
@@ -350,14 +350,14 @@ public:
 
         // Set the size
         unsigned int nSize = vSend.size() - nMessageStart;
-        memcpy((char*)&vSend[nHeaderStart] + offsetof(CMessageHeader, nMessageSize), &nSize, sizeof(nSize));
+        memcpy((char*)&vSend[nHeaderStart] + CMessageHeader::MESSAGE_SIZE_OFFSET, &nSize, sizeof(nSize));
 
         // Set the checksum
         uint256 hash = Hash(vSend.begin() + nMessageStart, vSend.end());
         unsigned int nChecksum = 0;
         memcpy(&nChecksum, &hash, sizeof(nChecksum));
-        assert(nMessageStart - nHeaderStart >= offsetof(CMessageHeader, nChecksum) + sizeof(nChecksum));
-        memcpy((char*)&vSend[nHeaderStart] + offsetof(CMessageHeader, nChecksum), &nChecksum, sizeof(nChecksum));
+        assert(nMessageStart - nHeaderStart >= CMessageHeader::CHECKSUM_OFFSET + sizeof(nChecksum));
+        memcpy((char*)&vSend[nHeaderStart] + CMessageHeader::CHECKSUM_OFFSET, &nChecksum, sizeof(nChecksum));
 
         if (fDebug) {
             printf("(%d bytes)\n", nSize);

--- a/src/netbase.cpp
+++ b/src/netbase.cpp
@@ -227,9 +227,9 @@ bool static Socks5(string strDest, int port, SOCKET& hSocket)
     }
     char pszSocks5Init[] = "\5\1\0";
     char *pszSocks5 = pszSocks5Init;
-    int nSize = sizeof(pszSocks5Init) - 1;
+    ssize_t nSize = sizeof(pszSocks5Init) - 1;
 
-    int ret = send(hSocket, pszSocks5, nSize, MSG_NOSIGNAL);
+    ssize_t ret = send(hSocket, pszSocks5, nSize, MSG_NOSIGNAL);
     if (ret != nSize)
     {
         closesocket(hSocket);
@@ -253,7 +253,7 @@ bool static Socks5(string strDest, int port, SOCKET& hSocket)
     strSocks5 += static_cast<char>((port >> 8) & 0xFF);
     strSocks5 += static_cast<char>((port >> 0) & 0xFF);
     ret = send(hSocket, strSocks5.c_str(), strSocks5.size(), MSG_NOSIGNAL);
-    if (ret != strSocks5.size())
+    if (ret != (ssize_t)strSocks5.size())
     {
         closesocket(hSocket);
         return error("Error sending to proxy");
@@ -959,7 +959,7 @@ bool operator<(const CService& a, const CService& b)
 bool CService::GetSockAddr(struct sockaddr* paddr, socklen_t *addrlen) const
 {
     if (IsIPv4()) {
-        if (*addrlen < sizeof(struct sockaddr_in))
+        if (*addrlen < (socklen_t)sizeof(struct sockaddr_in))
             return false;
         *addrlen = sizeof(struct sockaddr_in);
         struct sockaddr_in *paddrin = (struct sockaddr_in*)paddr;
@@ -972,7 +972,7 @@ bool CService::GetSockAddr(struct sockaddr* paddr, socklen_t *addrlen) const
     }
 #ifdef USE_IPV6
     if (IsIPv6()) {
-        if (*addrlen < sizeof(struct sockaddr_in6))
+        if (*addrlen < (socklen_t)sizeof(struct sockaddr_in6))
             return false;
         *addrlen = sizeof(struct sockaddr_in6);
         struct sockaddr_in6 *paddrin6 = (struct sockaddr_in6*)paddr;

--- a/src/primenodes.cpp
+++ b/src/primenodes.cpp
@@ -181,7 +181,7 @@ bool CTransaction::IsPrimeStake(CScript scriptPubKeyType, CScript scriptPubKeyAd
          * may be set temperately when it's known that a release will be done
          * that ensures people update before the real valid_until time occurs
          * and the real end date is unknown at the time of updating the keys. */
-        if (entry.valid_until != -1 && nTime >= entry.valid_until)
+        if (entry.valid_until != (unsigned int)-1 && nTime >= entry.valid_until)
             return DoS(100, error("IsPrimeStake() : prime node staking has ended for the given keypair"));
 
         primeNodeRate = entry.primeNodeRate;

--- a/src/protocol.h
+++ b/src/protocol.h
@@ -21,6 +21,7 @@
 #define TESTNET_RPC_PORT 9001
 
 extern bool fTestNet;
+extern unsigned char pchMessageStart[4];
 
 void GetMessageStart(unsigned char pchMessageStart[]);
 
@@ -55,8 +56,16 @@ class CMessageHeader
 
     // TODO: make private (improves encapsulation)
     public:
-        enum { COMMAND_SIZE=12 };
-        unsigned char pchMessageStart[4];
+        enum {
+            MESSAGE_START_SIZE=sizeof(::pchMessageStart),
+            COMMAND_SIZE=12,
+            MESSAGE_SIZE_SIZE=sizeof(int),
+            CHECKSUM_SIZE=sizeof(int),
+
+            MESSAGE_SIZE_OFFSET=MESSAGE_START_SIZE+COMMAND_SIZE,
+            CHECKSUM_OFFSET=MESSAGE_SIZE_OFFSET+MESSAGE_SIZE_SIZE
+        };
+        unsigned char pchMessageStart[MESSAGE_START_SIZE];
         char pchCommand[COMMAND_SIZE];
         unsigned int nMessageSize;
         unsigned int nChecksum;

--- a/src/qt/guiutil.cpp
+++ b/src/qt/guiutil.cpp
@@ -246,8 +246,8 @@ void openDebugLogfile()
 #endif
 }
 
-ToolTipToRichTextFilter::ToolTipToRichTextFilter(int size_threshold, QObject *parent):
-    size_threshold(size_threshold), QObject(parent)
+ToolTipToRichTextFilter::ToolTipToRichTextFilter(int size_threshold, QObject *parent) :
+    QObject(parent), size_threshold(size_threshold)
 {
 
 }

--- a/src/qt/guiutil.h
+++ b/src/qt/guiutil.h
@@ -77,11 +77,11 @@ namespace GUIUtil
       representation if needed. This assures that Qt can word-wrap long tooltip messages.
       Tooltips longer than the provided size threshold (in characters) are wrapped.
      */
-    class ToolTipToRichTextFilter: public QObject
+    class ToolTipToRichTextFilter : public QObject
     {
         Q_OBJECT
     public:
-        ToolTipToRichTextFilter(int size_threshold, QObject *parent);
+        explicit ToolTipToRichTextFilter(int size_threshold, QObject *parent = 0);
 
     protected:
         bool eventFilter(QObject *obj, QEvent *evt);

--- a/src/qt/multisigdialog.cpp
+++ b/src/qt/multisigdialog.cpp
@@ -381,7 +381,7 @@ void MultisigDialog::on_signTransactionButton_clicked()
 
     // Fetch previous transactions (inputs)
     std::map<COutPoint, CScript> mapPrevOut;
-    for(int i = 0; i < mergedTx.vin.size(); i++)
+    for(unsigned int i = 0; i < mergedTx.vin.size(); i++)
     {
         CTransaction tempTx;
         MapPrevTx mapPrevTx;
@@ -422,7 +422,7 @@ void MultisigDialog::on_signTransactionButton_clicked()
 
     // Sign what we can
     bool fComplete = true;
-    for(int i = 0; i < mergedTx.vin.size(); i++)
+    for(unsigned int i = 0; i < mergedTx.vin.size(); i++)
     {
         CTxIn& txin = mergedTx.vin[i];
         if(mapPrevOut.count(txin.prevout) == 0)

--- a/src/qt/multisiginputentry.cpp
+++ b/src/qt/multisiginputentry.cpp
@@ -52,7 +52,7 @@ CTxIn MultisigInputEntry::getInput()
 int64 MultisigInputEntry::getAmount()
 {
     int64 amount = 0;
-    int nOutput = ui->transactionOutput->currentIndex();
+    unsigned int nOutput = ui->transactionOutput->currentIndex();
     CTransaction tx;
     uint256 blockHash = 0;
 
@@ -115,7 +115,7 @@ void MultisigInputEntry::on_transactionId_textChanged(const QString &transaction
     uint256 blockHash = 0;
     if(!GetTransaction(txHash, tx, blockHash))
         return;
-    for(int i = 0; i < tx.vout.size(); i++)
+    for(unsigned int i = 0; i < tx.vout.size(); i++)
     {
         QString idStr;
         idStr.setNum(i);

--- a/src/qt/notificator.cpp
+++ b/src/qt/notificator.cpp
@@ -21,8 +21,10 @@
 extern bool qt_mac_execute_apple_script(const QString &script, AEDesc *ret);
 #endif
 
+#ifdef USE_DBUS
 // https://wiki.ubuntu.com/NotificationDevelopmentGuidelines recommends at least 128
 const int FREEDESKTOP_NOTIFICATION_ICON_SIZE = 128;
+#endif
 
 Notificator::Notificator(const QString &programName, QSystemTrayIcon *trayicon, QWidget *parent):
     QObject(parent),

--- a/src/qt/transactionrecord.cpp
+++ b/src/qt/transactionrecord.cpp
@@ -115,7 +115,7 @@ QList<TransactionRecord> TransactionRecord::decomposeTransaction(const CWallet *
                 //
                 int64 nTxFee = nDebit - wtx.GetValueOut();
 
-                for (int nOut = 0; nOut < wtx.vout.size(); nOut++)
+                for (unsigned int nOut = 0; nOut < wtx.vout.size(); nOut++)
                 {
                     const CTxOut& txout = wtx.vout[nOut];
                     TransactionRecord sub(hash, nTime);
@@ -253,4 +253,3 @@ std::string TransactionRecord::getTxID()
 {
     return hash.ToString(); // + strprintf("-%03d", idx);
 }
-

--- a/src/script.cpp
+++ b/src/script.cpp
@@ -950,7 +950,7 @@ bool EvalScript(vector<vector<unsigned char> >& stack, const CScript& script, co
                     // ([sig ...] num_of_signatures [pubkey ...] num_of_pubkeys -- bool)
 
                     int i = 1;
-                    if (stack.size() < i)
+                    if ((int)stack.size() < i)
                         return false;
 
                     int nKeysCount = CastToBigNum(stacktop(-i)).getint();
@@ -961,7 +961,7 @@ bool EvalScript(vector<vector<unsigned char> >& stack, const CScript& script, co
                         return false;
                     int ikey = ++i;
                     i += nKeysCount;
-                    if (stack.size() < i)
+                    if ((int)stack.size() < i)
                         return false;
 
                     int nSigsCount = CastToBigNum(stacktop(-i)).getint();
@@ -969,7 +969,7 @@ bool EvalScript(vector<vector<unsigned char> >& stack, const CScript& script, co
                         return false;
                     int isig = ++i;
                     i += nSigsCount;
-                    if (stack.size() < i)
+                    if ((int)stack.size() < i)
                         return false;
 
                     // Subset of script starting at the most recent codeseparator

--- a/src/wallet.cpp
+++ b/src/wallet.cpp
@@ -2138,7 +2138,7 @@ void CWallet::FixSpentCoins(int& nMismatchFound, int64& nBalanceInQuestion, bool
         CTxIndex txindex;
         if (!txdb.ReadTxIndex(pcoin->GetHash(), txindex))
             continue;
-        for (int n=0; n < pcoin->vout.size(); n++)
+        for (unsigned int n = 0; n < pcoin->vout.size(); n++)
         {
             if (IsMine(pcoin->vout[n]) && pcoin->IsSpent(n) && (txindex.vSpent.size() <= n || txindex.vSpent[n].IsNull()))
             {


### PR DESCRIPTION
This eliminates all non-compiler specific warnings when compiling on linux

Compiler specific warnings include hardening related flags showing as unused
in Clang and qt generated file prompting a warning when using GCC.

Eliminates most warnings in linux-mingw makefile with the exception of boost
related warnings and a windows header warning about the order includes are
done in.

While this builds fine and shouldn't cause any issues I'd like people to play with it a bit before merging. Specifically windows builds. Also a OS-X build has not been attempted with these changes. @jwrb you think you could run an OS-X build of this for me?