### PR TITLE
Remove stack randomization

### DIFF
--- a/src/bitcoinrpc.cpp
+++ b/src/bitcoinrpc.cpp
@@ -3216,8 +3216,6 @@ private:
 
 void ThreadRPCServer(void* parg)
 {
-    IMPLEMENT_RANDOMIZE_STACK(ThreadRPCServer(parg));
-
     // getwork/getblocktemplate mining rewards paid here:
     pMiningKey = new CReserveKey(pwalletMain);
 

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -636,7 +636,6 @@ void CNode::copyStats(CNodeStats &stats)
 
 void ThreadSocketHandler(void* parg)
 {
-    IMPLEMENT_RANDOMIZE_STACK(ThreadSocketHandler(parg));
     try
     {
         vnThreadsRunning[THREAD_SOCKETHANDLER]++;
@@ -998,7 +997,6 @@ void ThreadSocketHandler2(void* parg)
 #ifdef USE_UPNP
 void ThreadMapPort(void* parg)
 {
-    IMPLEMENT_RANDOMIZE_STACK(ThreadMapPort(parg));
     try
     {
         vnThreadsRunning[THREAD_UPNP]++;
@@ -1165,7 +1163,6 @@ static const char *strDNSSeed[][2] = {
 
 void ThreadDNSAddressSeed(void* parg)
 {
-    IMPLEMENT_RANDOMIZE_STACK(ThreadDNSAddressSeed(parg));
     try
     {
         vnThreadsRunning[THREAD_DNSSEED]++;
@@ -1258,7 +1255,6 @@ void ThreadDumpAddress2(void* parg)
 
 void ThreadDumpAddress(void* parg)
 {
-    IMPLEMENT_RANDOMIZE_STACK(ThreadDumpAddress(parg));
     try
     {
         ThreadDumpAddress2(parg);
@@ -1271,7 +1267,6 @@ void ThreadDumpAddress(void* parg)
 
 void ThreadOpenConnections(void* parg)
 {
-    IMPLEMENT_RANDOMIZE_STACK(ThreadOpenConnections(parg));
     try
     {
         vnThreadsRunning[THREAD_OPENCONNECTIONS]++;
@@ -1431,7 +1426,6 @@ void ThreadOpenConnections2(void* parg)
 
 void ThreadOpenAddedConnections(void* parg)
 {
-    IMPLEMENT_RANDOMIZE_STACK(ThreadOpenAddedConnections(parg));
     try
     {
         vnThreadsRunning[THREAD_ADDEDCONNECTIONS]++;
@@ -1575,7 +1569,6 @@ bool OpenNetworkConnection(const CAddress& addrConnect, CSemaphoreGrant *grantOu
 
 void ThreadMessageHandler(void* parg)
 {
-    IMPLEMENT_RANDOMIZE_STACK(ThreadMessageHandler(parg));
     try
     {
         vnThreadsRunning[THREAD_MESSAGEHANDLER]++;

--- a/src/util.h
+++ b/src/util.h
@@ -586,20 +586,6 @@ bool SoftSetBoolArg(const std::string& strArg, bool fValue);
 
 
 
-// Randomize the stack to help protect against buffer overrun exploits
-#define IMPLEMENT_RANDOMIZE_STACK(ThreadFn)     \
-    {                                           \
-        static char nLoops;                     \
-        if (nLoops <= 0)                        \
-            nLoops = GetRand(20) + 1;           \
-        if (nLoops-- > 1)                       \
-        {                                       \
-            ThreadFn;                           \
-            return;                             \
-        }                                       \
-    }
-
-
 template<typename T1>
 inline uint256 Hash(const T1 pbegin, const T1 pend)
 {


### PR DESCRIPTION
We currently have better measures to deal with stack overflow problems (-fstack-protector, ASLR, non-executable stack, ...) than this hack.

Furthermore, GCC optimizes the loop away through tail call optimization...

Reference:
https://github.com/bitcoin/bitcoin/commit/2e3ffb2d8234b12314d3e48a44e3e1cdfdaec182