### PR TITLE
Update detachdb comment in help

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -274,7 +274,7 @@ bool AppInit2(int argc, char* argv[])
 #else
             "  -upnp            \t  "   + _("Use Universal Plug and Play to map the listening port (default: 0)") + "\n" +
 #endif
-            "  -detachdb        \t  "   + _("Detach block and address databases. Increases shutdown time (default: 0)") + "\n" +
+            "  -detachdb        \t  "   + _("Detach block database. Increases shutdown time (default: 0)") + "\n" +
 #endif
             "  -paytxfee=<amt>  \t  "   + _("Fee per KB to add to transactions you send") + "\n" +
 #ifdef QT_GUI


### PR DESCRIPTION
Address database is no longer effected by this flag since the peers.dat
all other database are automatically detached by default.