### PR TITLE
Encapsulate BDB environment inside new CDBEnv class

### DIFF
--- a/src/db.cpp
+++ b/src/db.cpp
@@ -145,10 +145,7 @@ CDB::CDB(const char *pszFile, const char* pszMode) :
             {
                 delete pdb;
                 pdb = NULL;
-                {
-                     LOCK(bitdb.cs_db);
-                    --bitdb.mapFileUseCount[strFile];
-                }
+                --bitdb.mapFileUseCount[strFile];
                 strFile = "";
                 throw runtime_error(strprintf("CDB() : can't open database file %s, error %d", pszFile, ret));
             }

--- a/src/db.cpp
+++ b/src/db.cpp
@@ -174,9 +174,9 @@ void CDB::Close()
 {
     if (!pdb)
         return;
-    if (!vTxn.empty())
-        vTxn.front()->abort();
-    vTxn.clear();
+    if (activeTxn)
+        activeTxn->abort();
+    activeTxn = NULL;
     pdb = NULL;
 
     // Flush database activity from memory pool to disk log

--- a/src/db.cpp
+++ b/src/db.cpp
@@ -114,7 +114,8 @@ void CDBEnv::CheckpointLSN(std::string strFile)
     dbenv.lsn_reset(strFile.c_str(), 0);
 }
 
-CDB::CDB(const char *pszFile, const char* pszMode) : pdb(NULL)
+CDB::CDB(const char *pszFile, const char* pszMode) :
+    pdb(NULL), activeTxn(NULL)
 {
     int ret;
     if (pszFile == NULL)

--- a/src/db.cpp
+++ b/src/db.cpp
@@ -31,14 +31,11 @@ unsigned int nWalletDBUpdated;
 // CDB
 //
 
-CCriticalSection cs_db;
-static bool fDbEnvInit = false;
-bool fDetachDB = false;
-DbEnv dbenv(0);
+CDBEnv bitdb;
 map<string, int> mapFileUseCount;
 static map<string, Db*> mapDb;
 
-static void EnvShutdown()
+void CDBEnv::EnvShutdown()
 {
     if (!fDbEnvInit)
         return;
@@ -55,19 +52,67 @@ static void EnvShutdown()
     DbEnv(0).remove(GetDataDir().string().c_str(), 0);
 }
 
-class CDBInit
+CDBEnv::CDBEnv() : dbenv(0)
 {
-public:
-    CDBInit()
-    {
-    }
-    ~CDBInit()
-    {
-        EnvShutdown();
-    }
 }
-instance_of_cdbinit;
 
+CDBEnv::~CDBEnv()
+{
+    EnvShutdown();
+}
+
+void CDBEnv::Close()
+{
+    EnvShutdown();
+}
+
+bool CDBEnv::Open(boost::filesystem::path pathEnv_)
+{
+    if (fDbEnvInit)
+        return true;
+
+    if (fShutdown)
+        return false;
+
+    pathEnv = pathEnv_;
+    filesystem::path pathDataDir = pathEnv;
+    filesystem::path pathLogDir = pathDataDir / "database";
+    filesystem::create_directory(pathLogDir);
+    filesystem::path pathErrorFile = pathDataDir / "db.log";
+    printf("dbenv.open LogDir=%s ErrorFile=%s\n", pathLogDir.string().c_str(), pathErrorFile.string().c_str());
+
+    int nDbCache = GetArg("-dbcache", 25);
+    dbenv.set_lg_dir(pathLogDir.string().c_str());
+    dbenv.set_cachesize(nDbCache / 1024, (nDbCache % 1024)*1048576, 1);
+    dbenv.set_lg_bsize(1048576);
+    dbenv.set_lg_max(10485760);
+    dbenv.set_lk_max_locks(10000);
+    dbenv.set_lk_max_objects(10000);
+    dbenv.set_errfile(fopen(pathErrorFile.string().c_str(), "a")); /// debug
+    dbenv.set_flags(DB_AUTO_COMMIT, 1);
+    dbenv.set_flags(DB_TXN_WRITE_NOSYNC, 1);
+    dbenv.log_set_config(DB_LOG_AUTO_REMOVE, 1);
+    int ret = dbenv.open(pathDataDir.string().c_str(),
+                     DB_CREATE     |
+                     DB_INIT_LOCK  |
+                     DB_INIT_LOG   |
+                     DB_INIT_MPOOL |
+                     DB_INIT_TXN   |
+                     DB_THREAD     |
+                     DB_RECOVER,
+                     S_IRUSR | S_IWUSR);
+    if (ret > 0)
+        return error("CDB() : error %d opening database environment", ret);
+
+    fDbEnvInit = true;
+    return true;
+}
+
+void CDBEnv::CheckpointLSN(std::string strFile)
+{
+    dbenv.txn_checkpoint(0, 0, 0);
+    dbenv.lsn_reset(strFile.c_str(), 0);
+}
 
 CDB::CDB(const char *pszFile, const char* pszMode) : pdb(NULL)
 {
@@ -82,48 +127,16 @@ CDB::CDB(const char *pszFile, const char* pszMode) : pdb(NULL)
         nFlags |= DB_CREATE;
 
     {
-        LOCK(cs_db);
-        if (!fDbEnvInit)
-        {
-            if (fShutdown)
-                return;
-            filesystem::path pathDataDir = GetDataDir();
-            filesystem::path pathLogDir = pathDataDir / "database";
-            filesystem::create_directory(pathLogDir);
-            filesystem::path pathErrorFile = pathDataDir / "db.log";
-            printf("dbenv.open LogDir=%s ErrorFile=%s\n", pathLogDir.string().c_str(), pathErrorFile.string().c_str());
-
-            int nDbCache = GetArg("-dbcache", 25);
-            dbenv.set_lg_dir(pathLogDir.string().c_str());
-            dbenv.set_cachesize(nDbCache / 1024, (nDbCache % 1024)*1048576, 1);
-            dbenv.set_lg_bsize(1048576);
-            dbenv.set_lg_max(10485760);
-            dbenv.set_lk_max_locks(10000);
-            dbenv.set_lk_max_objects(10000);
-            dbenv.set_errfile(fopen(pathErrorFile.string().c_str(), "a")); /// debug
-            dbenv.set_flags(DB_TXN_WRITE_NOSYNC, 1);
-            dbenv.set_flags(DB_AUTO_COMMIT, 1);
-            dbenv.log_set_config(DB_LOG_AUTO_REMOVE, 1);
-            ret = dbenv.open(pathDataDir.string().c_str(),
-                             DB_CREATE     |
-                             DB_INIT_LOCK  |
-                             DB_INIT_LOG   |
-                             DB_INIT_MPOOL |
-                             DB_INIT_TXN   |
-                             DB_THREAD     |
-                             DB_RECOVER,
-                             S_IRUSR | S_IWUSR);
-            if (ret > 0)
-                throw runtime_error(strprintf("CDB() : error %d opening database environment", ret));
-            fDbEnvInit = true;
-        }
+        LOCK(bitdb.cs_db);
+        if (!bitdb.Open(GetDataDir()))
+            throw runtime_error("env open failed");
 
         strFile = pszFile;
         ++mapFileUseCount[strFile];
         pdb = mapDb[strFile];
         if (pdb == NULL)
         {
-            pdb = new Db(&dbenv, 0);
+            pdb = new Db(&bitdb.dbenv, 0);
 
             ret = pdb->open(NULL,      // Txn pointer
                             pszFile,   // Filename
@@ -137,7 +150,7 @@ CDB::CDB(const char *pszFile, const char* pszMode) : pdb(NULL)
                 delete pdb;
                 pdb = NULL;
                 {
-                     LOCK(cs_db);
+                     LOCK(bitdb.cs_db);
                     --mapFileUseCount[strFile];
                 }
                 strFile = "";
@@ -179,10 +192,10 @@ void CDB::Close()
     if (strFile == "blkindex.dat" && IsInitialBlockDownload())
         nMinutes = 5;
 
-    dbenv.txn_checkpoint(nMinutes ? GetArg("-dblogsize", 100)*1024 : 0, nMinutes, 0);
+    bitdb.dbenv.txn_checkpoint(nMinutes ? GetArg("-dblogsize", 100)*1024 : 0, nMinutes, 0);
 
     {
-        LOCK(cs_db);
+        LOCK(bitdb.cs_db);
         --mapFileUseCount[strFile];
     }
 }
@@ -190,7 +203,7 @@ void CDB::Close()
 void CloseDb(const string& strFile)
 {
     {
-        LOCK(cs_db);
+        LOCK(bitdb.cs_db);
         if (mapDb[strFile] != NULL)
         {
             // Close the database handle
@@ -207,13 +220,12 @@ bool CDB::Rewrite(const string& strFile, const char* pszSkip)
     while (!fShutdown)
     {
         {
-            LOCK(cs_db);
+            LOCK(bitdb.cs_db);
             if (!mapFileUseCount.count(strFile) || mapFileUseCount[strFile] == 0)
             {
                 // Flush log data to the dat file
                 CloseDb(strFile);
-                dbenv.txn_checkpoint(0, 0, 0);
-                dbenv.lsn_reset(strFile.c_str(), 0);
+                bitdb.CheckpointLSN(strFile);
                 mapFileUseCount.erase(strFile);
 
                 bool fSuccess = true;
@@ -221,7 +233,7 @@ bool CDB::Rewrite(const string& strFile, const char* pszSkip)
                 string strFileRes = strFile + ".rewrite";
                 { // surround usage of db with extra {}
                     CDB db(strFile.c_str(), "r");
-                    Db* pdbCopy = new Db(&dbenv, 0);
+                    Db* pdbCopy = new Db(&bitdb.dbenv, 0);
 
                     int ret = pdbCopy->open(NULL,                 // Txn pointer
                                             strFileRes.c_str(),   // Filename
@@ -279,10 +291,10 @@ bool CDB::Rewrite(const string& strFile, const char* pszSkip)
                 }
                 if (fSuccess)
                 {
-                    Db dbA(&dbenv, 0);
+                    Db dbA(&bitdb.dbenv, 0);
                     if (dbA.remove(strFile.c_str(), NULL, 0))
                         fSuccess = false;
-                    Db dbB(&dbenv, 0);
+                    Db dbB(&bitdb.dbenv, 0);
                     if (dbB.rename(strFileRes.c_str(), NULL, strFile.c_str(), 0))
                         fSuccess = false;
                 }
@@ -297,11 +309,11 @@ bool CDB::Rewrite(const string& strFile, const char* pszSkip)
 }
 
 
-void DBFlush(bool fShutdown)
+void CDBEnv::Flush(bool fShutdown)
 {
     // Flush log data to the actual data file
     //  on all files that are not in use
-    printf("DBFlush(%s)%s\n", fShutdown ? "true" : "false", fDbEnvInit ? "" : " db not started");
+    printf("Flush(%s)%s\n", fShutdown ? "true" : "false", fDbEnvInit ? "" : " db not started");
     if (!fDbEnvInit)
         return;
     {
@@ -334,7 +346,7 @@ void DBFlush(bool fShutdown)
             if (mapFileUseCount.empty())
             {
                 dbenv.log_archive(&listp, DB_ARCH_REMOVE);
-                EnvShutdown();
+                Close();
             }
         }
     }

--- a/src/db.cpp
+++ b/src/db.cpp
@@ -22,18 +22,13 @@
 using namespace std;
 using namespace boost;
 
-
 unsigned int nWalletDBUpdated;
-
-
 
 //
 // CDB
 //
 
 CDBEnv bitdb;
-map<string, int> mapFileUseCount;
-static map<string, Db*> mapDb;
 
 void CDBEnv::EnvShutdown()
 {
@@ -133,8 +128,8 @@ CDB::CDB(const char *pszFile, const char* pszMode) :
             throw runtime_error("env open failed");
 
         strFile = pszFile;
-        ++mapFileUseCount[strFile];
-        pdb = mapDb[strFile];
+        ++bitdb.mapFileUseCount[strFile];
+        pdb = bitdb.mapDb[strFile];
         if (pdb == NULL)
         {
             pdb = new Db(&bitdb.dbenv, 0);
@@ -152,7 +147,7 @@ CDB::CDB(const char *pszFile, const char* pszMode) :
                 pdb = NULL;
                 {
                      LOCK(bitdb.cs_db);
-                    --mapFileUseCount[strFile];
+                    --bitdb.mapFileUseCount[strFile];
                 }
                 strFile = "";
                 throw runtime_error(strprintf("CDB() : can't open database file %s, error %d", pszFile, ret));
@@ -166,7 +161,7 @@ CDB::CDB(const char *pszFile, const char* pszMode) :
                 fReadOnly = fTmp;
             }
 
-            mapDb[strFile] = pdb;
+            bitdb.mapDb[strFile] = pdb;
         }
     }
 }
@@ -197,14 +192,14 @@ void CDB::Close()
 
     {
         LOCK(bitdb.cs_db);
-        --mapFileUseCount[strFile];
+        --bitdb.mapFileUseCount[strFile];
     }
 }
 
-void CloseDb(const string& strFile)
+void CDBEnv::CloseDb(const string& strFile)
 {
     {
-        LOCK(bitdb.cs_db);
+        LOCK(cs_db);
         if (mapDb[strFile] != NULL)
         {
             // Close the database handle
@@ -222,12 +217,12 @@ bool CDB::Rewrite(const string& strFile, const char* pszSkip)
     {
         {
             LOCK(bitdb.cs_db);
-            if (!mapFileUseCount.count(strFile) || mapFileUseCount[strFile] == 0)
+            if (!bitdb.mapFileUseCount.count(strFile) || bitdb.mapFileUseCount[strFile] == 0)
             {
                 // Flush log data to the dat file
-                CloseDb(strFile);
+                bitdb.CloseDb(strFile);
                 bitdb.CheckpointLSN(strFile);
-                mapFileUseCount.erase(strFile);
+                bitdb.mapFileUseCount.erase(strFile);
 
                 bool fSuccess = true;
                 printf("Rewriting %s...\n", strFile.c_str());
@@ -284,7 +279,7 @@ bool CDB::Rewrite(const string& strFile, const char* pszSkip)
                     if (fSuccess)
                     {
                         db.Close();
-                        CloseDb(strFile);
+                        bitdb.CloseDb(strFile);
                         if (pdbCopy->close(0))
                             fSuccess = false;
                         delete pdbCopy;

--- a/src/db.h
+++ b/src/db.h
@@ -43,6 +43,8 @@ private:
 public:
     mutable CCriticalSection cs_db;
     DbEnv dbenv;
+    std::map<std::string, int> mapFileUseCount;
+    std::map<std::string, Db*> mapDb;
 
     CDBEnv();
     ~CDBEnv();
@@ -57,6 +59,8 @@ public:
      * to be checked outside of CDBEnv as a wortkaround until a more proper
      * solution is determined. */
     bool GetDetached() { return fDetachDB; }
+
+    void CloseDb(const std::string& strFile);
 
     DbTxn *TxnBegin(int flags=DB_TXN_WRITE_NOSYNC)
     {

--- a/src/db.h
+++ b/src/db.h
@@ -57,6 +57,15 @@ public:
      * to be checked outside of CDBEnv as a wortkaround until a more proper
      * solution is determined. */
     bool GetDetached() { return fDetachDB; }
+
+    DbTxn *TxnBegin(DbTxn *baseTxn, int flags=DB_TXN_WRITE_NOSYNC)
+    {
+        DbTxn* ptxn = NULL;
+        int ret = dbenv.txn_begin(baseTxn, &ptxn, flags);
+        if (!ptxn || ret != 0)
+            return NULL;
+        return ptxn;
+    }
 };
 
 extern CDBEnv bitdb;
@@ -248,9 +257,8 @@ public:
     {
         if (!pdb)
             return false;
-        DbTxn* ptxn = NULL;
-        int ret = bitdb.dbenv.txn_begin(GetTxn(), &ptxn, DB_TXN_WRITE_NOSYNC);
-        if (!ptxn || ret != 0)
+        DbTxn* ptxn = bitdb.TxnBegin(GetTxn());
+        if (!ptxn)
             return false;
         vTxn.push_back(ptxn);
         return true;

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -80,9 +80,9 @@ void Shutdown(void* parg)
             primeNodeDB->Close();
         if (scrapesDB)
             scrapesDB->Close();
-        DBFlush(false);
+        bitdb.Flush(false);
         StopNode();
-        DBFlush(true);
+        bitdb.Flush(true);
         boost::filesystem::remove(GetPidFile());
         UnregisterWallet(pwalletMain);
         delete pwalletMain;
@@ -328,7 +328,7 @@ bool AppInit2(int argc, char* argv[])
     fTestNet = GetBoolArg("-testnet");
 
     fDebug = GetBoolArg("-debug");
-    fDetachDB = GetBoolArg("-detachdb", false);
+    bitdb.SetDetach(GetBoolArg("-detachdb", false));
 
 #if !defined(WIN32) && !defined(QT_GUI)
     fDaemon = GetBoolArg("-daemon");

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1664,7 +1664,6 @@ bool Reorganize(CTxDB& txdb, CBlockIndex* pindexNew)
         if (!block.ConnectBlock(txdb, pindex))
         {
             // Invalid block
-            txdb.TxnAbort();
             return error("Reorganize() : ConnectBlock %s failed", pindex->GetBlockHash().ToString().substr(0,20).c_str());
         }
 

--- a/src/primenodes.cpp
+++ b/src/primenodes.cpp
@@ -230,7 +230,7 @@ void InflatePrimeNodeDB(dbtype db) {
     printf("InflatePrimeNodeDB() : Primenode database is inconsistent, inflating database.\n");
     // Db is open in read-only mode, close and reopen it with write privs.
     primeNodeDB->Close();
-    CloseDb("primenodes.dat");
+    bitdb.CloseDb("primenodes.dat");
     delete primeNodeDB;
     primeNodeDB = new CPrimeNodeDB("w+");
 
@@ -243,7 +243,7 @@ void InflatePrimeNodeDB(dbtype db) {
     /* Close Db and reopen it w/ read-only privs because we won't need to write
      * to it again. */
     primeNodeDB->Close();
-    CloseDb("primenodes.dat");
+    bitdb.CloseDb("primenodes.dat");
     delete primeNodeDB;
     primeNodeDB = new CPrimeNodeDB("r");
 }

--- a/src/qt/optionsmodel.cpp
+++ b/src/qt/optionsmodel.cpp
@@ -125,7 +125,7 @@ QVariant OptionsModel::data(const QModelIndex & index, int role) const
         case DisplayAddresses:
             return QVariant(bDisplayAddresses);
         case DetachDatabases:
-            return QVariant(fDetachDB);
+            return QVariant(bitdb.GetDetached());
         case CoinControlFeatures:
             return QVariant(fCoinControlFeatures);
         default:
@@ -213,8 +213,8 @@ bool OptionsModel::setData(const QModelIndex & index, const QVariant & value, in
             }
             break;
         case DetachDatabases: {
-            fDetachDB = value.toBool();
-            settings.setValue("detachDB", fDetachDB);
+            bitdb.SetDetach(value.toBool());
+            settings.setValue("detachDB", bitdb.GetDetached());
             }
             break;
         case CoinControlFeatures: {

--- a/src/walletdb.cpp
+++ b/src/walletdb.cpp
@@ -12,11 +12,7 @@
 using namespace std;
 using namespace boost;
 
-
 static uint64 nAccountingEntryNumber = 0;
-
-extern map<string, int> mapFileUseCount;
-extern void CloseDb(const string& strFile);
 
 //
 // CWalletDB
@@ -356,8 +352,8 @@ void ThreadFlushWalletDB(void* parg)
             {
                 // Don't do this if any databases are in use
                 int nRefCount = 0;
-                map<string, int>::iterator mi = mapFileUseCount.begin();
-                while (mi != mapFileUseCount.end())
+                map<string, int>::iterator mi = bitdb.mapFileUseCount.begin();
+                while (mi != bitdb.mapFileUseCount.end())
                 {
                     nRefCount += (*mi).second;
                     mi++;
@@ -365,18 +361,18 @@ void ThreadFlushWalletDB(void* parg)
 
                 if (nRefCount == 0 && !fShutdown)
                 {
-                    map<string, int>::iterator mi = mapFileUseCount.find(strFile);
-                    if (mi != mapFileUseCount.end())
+                    map<string, int>::iterator mi = bitdb.mapFileUseCount.find(strFile);
+                    if (mi != bitdb.mapFileUseCount.end())
                     {
                         printf("Flushing wallet.dat\n");
                         nLastFlushed = nWalletDBUpdated;
                         int64 nStart = GetTimeMillis();
 
                         // Flush wallet.dat so it's self contained
-                        CloseDb(strFile);
+                        bitdb.CloseDb(strFile);
                         bitdb.CheckpointLSN(strFile);
 
-                        mapFileUseCount.erase(mi++);
+                        bitdb.mapFileUseCount.erase(mi++);
                         printf("Flushed wallet.dat %"PRI64d"ms\n", GetTimeMillis() - nStart);
                     }
                 }
@@ -393,12 +389,12 @@ bool BackupWallet(const CWallet& wallet, const string& strDest)
     {
         {
             LOCK(bitdb.cs_db);
-            if (!mapFileUseCount.count(wallet.strWalletFile) || mapFileUseCount[wallet.strWalletFile] == 0)
+            if (!bitdb.mapFileUseCount.count(wallet.strWalletFile) || bitdb.mapFileUseCount[wallet.strWalletFile] == 0)
             {
                 // Flush log data to the dat file
-                CloseDb(wallet.strWalletFile);
+                bitdb.CloseDb(wallet.strWalletFile);
                 bitdb.CheckpointLSN(wallet.strWalletFile);
-                mapFileUseCount.erase(wallet.strWalletFile);
+                bitdb.mapFileUseCount.erase(wallet.strWalletFile);
 
                 // Copy wallet.dat
                 filesystem::path pathSrc = GetDataDir() / wallet.strWalletFile;

--- a/src/walletdb.cpp
+++ b/src/walletdb.cpp
@@ -15,7 +15,6 @@ using namespace boost;
 
 static uint64 nAccountingEntryNumber = 0;
 
-extern CCriticalSection cs_db;
 extern map<string, int> mapFileUseCount;
 extern void CloseDb(const string& strFile);
 
@@ -352,7 +351,7 @@ void ThreadFlushWalletDB(void* parg)
 
         if (nLastFlushed != nWalletDBUpdated && GetTime() - nLastWalletUpdate >= 2)
         {
-            TRY_LOCK(cs_db,lockDb);
+            TRY_LOCK(bitdb.cs_db,lockDb);
             if (lockDb)
             {
                 // Don't do this if any databases are in use
@@ -375,8 +374,7 @@ void ThreadFlushWalletDB(void* parg)
 
                         // Flush wallet.dat so it's self contained
                         CloseDb(strFile);
-                        dbenv.txn_checkpoint(0, 0, 0);
-                        dbenv.lsn_reset(strFile.c_str(), 0);
+                        bitdb.CheckpointLSN(strFile);
 
                         mapFileUseCount.erase(mi++);
                         printf("Flushed wallet.dat %"PRI64d"ms\n", GetTimeMillis() - nStart);
@@ -394,13 +392,12 @@ bool BackupWallet(const CWallet& wallet, const string& strDest)
     while (!fShutdown)
     {
         {
-            LOCK(cs_db);
+            LOCK(bitdb.cs_db);
             if (!mapFileUseCount.count(wallet.strWalletFile) || mapFileUseCount[wallet.strWalletFile] == 0)
             {
                 // Flush log data to the dat file
                 CloseDb(wallet.strWalletFile);
-                dbenv.txn_checkpoint(0, 0, 0);
-                dbenv.lsn_reset(wallet.strWalletFile.c_str(), 0);
+                bitdb.CheckpointLSN(wallet.strWalletFile);
                 mapFileUseCount.erase(wallet.strWalletFile);
 
                 // Copy wallet.dat


### PR DESCRIPTION
Minor differences between this and the commits in question (specifically cd9696f) as this doesn't account for the needed changes to compile QT; was unable to locate a patch for this so instead wrote in the required functionality myself (subsequently this may not exactly match bitcoins implementation, I believe they actually did something similar at a later time (based on the commits where BDB was removed from everything but the wallet).

This (among other things) is needed to incorporate salvage functionality for corrupt wallet.dat files.

Works fine in my testing on linux but should definitely have some extended testing in all supported OS.

reference: https://github.com/bitcoin/bitcoin/pull/1293