### PR TITLE
Check primenode keys on app start

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -536,7 +536,15 @@ bool AppInit2(int argc, char* argv[])
     InitMessage(_("Loading prime nodes..."));
     printf("Loading prime nodes...");
     nStart = GetTimeMillis();
-    initPrimeNodes();
+    /* Handle primenode keys on start to confirm their validity.
+     * If it fails for any reason prompt with a QT friendly message. */
+    string ret;
+    if (!initPrimeNodes(ret)) {
+        strErrors << ret << "\n";
+    } else if (!ret.empty()) {
+        InitMessage(ret);
+        printf("%s\n", ret.c_str());
+    }
     printf(" prime nodes %15"PRI64d"ms\n", GetTimeMillis() - nStart);
 
     InitMessage(_("Loading scrapes..."));

--- a/src/primenodes.h
+++ b/src/primenodes.h
@@ -12,7 +12,9 @@ void WritePrimeNodeDB();
 void WriteMicroPrimeDB();
 void WriteTestMicroPrimeDB();
 
-/* This is used to unseralize the a database entry retaining all of the the
+bool NewScriptPrimeID(CScript &/*scriptPrimeID*/, unsigned int /*nTime*/);
+
+/* This is used to unseralize a database entry retaining all of the
  * primenode information */
 class CPrimeNodeDBEntry
 {

--- a/src/primenodes.h
+++ b/src/primenodes.h
@@ -7,7 +7,7 @@
 #include "db.h"
 #include "script.h"
 
-void initPrimeNodes();
+bool initPrimeNodes(std::string &/*ret*/);
 void WritePrimeNodeDB();
 void WriteMicroPrimeDB();
 void WriteTestMicroPrimeDB();

--- a/src/wallet.cpp
+++ b/src/wallet.cpp
@@ -1292,7 +1292,7 @@ bool CWallet::CreateCoinStake(const CKeyStore& keystore, unsigned int nBits, int
     txNew.vin.clear();
     txNew.vout.clear();
 
-    // Make variable interested rate
+    // Make variable interest rate
     unsigned int primeNodeRate = 0;
     int64 microPrimeGroup;
 
@@ -1307,11 +1307,8 @@ bool CWallet::CreateCoinStake(const CKeyStore& keystore, unsigned int nBits, int
         uint256 hashScriptTime = Hash(scriptTime.begin(), scriptTime.end());
         std::vector<unsigned char> vchSig;
 
-        if(!key.Sign(hashScriptTime, vchSig)){
-            return error("CreateCoinStake : Unable to sign checkpoint, wrong primenodekey?");
-        }else{
-            printf("Primenode key is correct for activating a prime controller\n");
-        }
+        if(!key.Sign(hashScriptTime, vchSig)) // This should not occur as this is checked at init.
+            return error("CreateCoinStake : Unable to sign checkpoint, possible invalid key format");
 
         CScript scriptPrimeNode;
         scriptPrimeNode << OP_PRIMENODEP2 << vchSig;

--- a/src/wallet.cpp
+++ b/src/wallet.cpp
@@ -1296,26 +1296,15 @@ bool CWallet::CreateCoinStake(const CKeyStore& keystore, unsigned int nBits, int
     unsigned int primeNodeRate = 0;
     int64 microPrimeGroup;
 
-    if (mapArgs.count("-primenodekey")) // paycoin: primenode priv key
+    if (mapArgs.count("-primenodekey"))
     {
-        std::string strPrivKey = GetArg("-primenodekey", "");
-        std::vector<unsigned char> vchPrivKey = ParseHex(strPrivKey);
-        CKey key;
-        key.SetPrivKey(CPrivKey(vchPrivKey.begin(), vchPrivKey.end())); // if key is not correct openssl may crash
-        CScript scriptTime;
-        scriptTime << txNew.nTime;
-        uint256 hashScriptTime = Hash(scriptTime.begin(), scriptTime.end());
-        std::vector<unsigned char> vchSig;
-
-        if(!key.Sign(hashScriptTime, vchSig)) // This should not occur as this is checked at init.
-            return error("CreateCoinStake : Unable to sign checkpoint, possible invalid key format");
-
         CScript scriptPrimeNode;
-        scriptPrimeNode << OP_PRIMENODEP2 << vchSig;
+        if (!NewScriptPrimeID(scriptPrimeNode, txNew.nTime))
+            return false;
+
         primeNodeRate = 25;
         nCombineThreshold = MINIMUM_FOR_PRIMENODE;
 
-        printf("Primenode rate for staking is %d\n", primeNodeRate);
         txNew.vout.push_back(CTxOut(0, scriptPrimeNode));
      }
 


### PR DESCRIPTION
Previously entering an invalid primenode key would start the wallet without error, if it was an invalid format it had the potential to throw an error otherwise the wallet would attempt to stake and not say the key was invalid until finding and creating a stake transaction and attempting to Accept the block (failing during ConnectInputs).

This will create a test signature and process it during init prompting if the key is invalid.