### PR TITLE
Fix display of external scrape transactions in qt wallet.

### DIFF
--- a/src/qt/transactionrecord.h
+++ b/src/qt/transactionrecord.h
@@ -69,7 +69,8 @@ public:
         RecvWithAddress,
         RecvFromOther,
         SendToSelf,
-        StakeMint
+        StakeMint,
+        ExternalScrape
     };
 
     /** Number of confirmation needed for transaction */

--- a/src/qt/transactiontablemodel.cpp
+++ b/src/qt/transactiontablemodel.cpp
@@ -293,7 +293,7 @@ QString TransactionTableModel::formatTxStatus(const TransactionRecord *wtx) cons
         status = tr("Confirmed (%1 confirmations)").arg(wtx->status.depth);
         break;
     }
-    if(wtx->type == TransactionRecord::Generated || wtx->type == TransactionRecord::StakeMint)
+    if(wtx->type == TransactionRecord::Generated || wtx->type == TransactionRecord::StakeMint || wtx->type == TransactionRecord::ExternalScrape)
     {
         switch(wtx->status.maturity)
         {
@@ -362,6 +362,8 @@ QString TransactionTableModel::formatTxType(const TransactionRecord *wtx) const
         return tr("Mined");
     case TransactionRecord::StakeMint:
         return tr("Mint by stake");
+    case TransactionRecord::ExternalScrape:
+        return tr("External scrape");
     default:
         return QString();
     }
@@ -394,6 +396,7 @@ QString TransactionTableModel::formatTxToAddress(const TransactionRecord *wtx, b
     case TransactionRecord::RecvWithAddress:
     case TransactionRecord::SendToAddress:
     case TransactionRecord::StakeMint:
+    case TransactionRecord::ExternalScrape:
         return lookupAddress(wtx->address, tooltip);
     case TransactionRecord::SendToOther:
         return QString::fromStdString(wtx->address);
@@ -412,6 +415,7 @@ QVariant TransactionTableModel::addressColor(const TransactionRecord *wtx) const
     case TransactionRecord::RecvWithAddress:
     case TransactionRecord::SendToAddress:
     case TransactionRecord::StakeMint:
+    case TransactionRecord::ExternalScrape:
         {
         QString label = walletModel->getAddressTableModel()->labelForAddress(QString::fromStdString(wtx->address));
         if(label.isEmpty())
@@ -441,7 +445,7 @@ QString TransactionTableModel::formatTxAmount(const TransactionRecord *wtx, bool
 
 QVariant TransactionTableModel::txStatusDecoration(const TransactionRecord *wtx) const
 {
-    if(wtx->type == TransactionRecord::Generated || wtx->type == TransactionRecord::StakeMint)
+    if(wtx->type == TransactionRecord::Generated || wtx->type == TransactionRecord::StakeMint || wtx->type == TransactionRecord::ExternalScrape)
     {
         switch(wtx->status.maturity)
         {
@@ -628,4 +632,3 @@ QModelIndex TransactionTableModel::index(int row, int column, const QModelIndex 
         return QModelIndex();
     }
 }
-


### PR DESCRIPTION
There's a weird issue in the QT where it doesn't always calculate the correct credit value on external stakes (sometimes and often resulting in displaying the complete stake value). The scrape value is always the value of the last output of the transaction so check it when setting the amount for an external scrape.

Label external scrapes differently then standard stakes and always list the address scraped from.

Before:
![selection_135](https://cloud.githubusercontent.com/assets/922158/10258833/8a2d7cd6-6927-11e5-9fb0-1d675e729e73.png)

After (with an address label set in address book):
![selection_134](https://cloud.githubusercontent.com/assets/922158/10258838/910913b2-6927-11e5-92a6-edf8fc2ade9d.png)
