### PR TITLE
Cleanup primenode header declarations

### DIFF
--- a/src/main.h
+++ b/src/main.h
@@ -45,14 +45,9 @@ static const unsigned int POW_START_TIME = 1418403600; // Fri 12 Dec 2014 12:00:
 static const unsigned int POW_END_TIME = 1419181200; // Sun 21 Dec 2014 12:00:00 PM EST
 // MODIFIER_INTERVAL: time to elapse before new modifier is computed
 static const unsigned int MODIFIER_INTERVAL = 10 * 60;
-static const int64 NUMBER_OF_PRIMENODE = 50;
 static const int64 MINIMUM_FOR_ORION = 50 * COIN;
-static const int64 MINIMUM_FOR_PRIMENODE = 160000 * COIN;
-static const int64 MINIMUM_FOR_PRIMENODE_OLD = 125000 * COIN;
 static const int MAX_TIME_SINCE_BEST_BLOCK = 10; // how many seconds to wait before sending next PushGetBlocks()
-// Reset all primenode stakerates to 100% after the given date
-static const unsigned int RESET_PRIMERATES = 1429531200; // Mon, 20 Apr 2015 12:00:00 GMT
-static const unsigned int END_PRIME_PHASE_ONE = 1435752000; // Wed, 01 Jul 2015 12:00:00 GMT
+
 // Enable phase 2 primenodes because of issue w/ IsProofOfStake check in previous update
 static const unsigned int ENABLE_PHASE_TWO_PRIMES = 1442318400; // Tue, 15 Sep 2015 12:00:00 GMT
 

--- a/src/primenodes.cpp
+++ b/src/primenodes.cpp
@@ -12,6 +12,9 @@ extern void CloseDb(const string& strFile);
 
 CPrimeNodeDB* primeNodeDB;
 
+// Reset all primenode stakerates to 100% after the given date
+static const unsigned int RESET_PRIMERATES = 1429531200; // Mon, 20 Apr 2015 12:00:00 GMT
+
 bool NewScriptPrimeID(CScript &scriptPrimeID, vector<unsigned char> vchPrivKey, unsigned int nTime) {
     CKey key;
     key.SetPrivKey(CPrivKey(vchPrivKey.begin(), vchPrivKey.end()));
@@ -176,10 +179,10 @@ bool CTransaction::IsPrimeStake(CScript scriptPubKeyType, CScript scriptPubKeyAd
     }
 
     // Confirm the stake passes the minimum for a primenode
-    if (nTime >= END_PRIME_PHASE_ONE && nValueOut < MINIMUM_FOR_PRIMENODE)
-        return DoS(100, error("IsPrimeStake() : credit doesn't meet requirement for primenode = %lld while you only have %lld", MINIMUM_FOR_PRIMENODE, nValueOut));
-    if (nValueOut < MINIMUM_FOR_PRIMENODE_OLD)
-        return DoS(100, error("IsPrimeStake() : credit doesn't meet requirement for primenode = %lld while you only have %lld", MINIMUM_FOR_PRIMENODE_OLD, nValueOut));
+    if (nTime >= END_PRIME_PHASE_ONE && GetValueOut() < MINIMUM_FOR_PRIMENODE_PHASE2)
+        return DoS(100, error("IsPrimeStake() : credit doesn't meet requirement for primenode = %lld while you only have %lld", MINIMUM_FOR_PRIMENODE_PHASE2, GetValueOut()));
+    if (GetValueOut() < MINIMUM_FOR_PRIMENODE_PHASE1)
+        return DoS(100, error("IsPrimeStake() : credit doesn't meet requirement for primenode = %lld while you only have %lld", MINIMUM_FOR_PRIMENODE_PHASE1, GetValueOut()));
 
     /* Reset the primeNodeRate to 100 on the Legacy Phase 1 primenodes after the
      * specified time. Stakes existing prior to that or created after the end of
@@ -253,8 +256,6 @@ bool CPrimeNodeDB::IsPrimeNodeKey(CScript scriptPubKeyType, unsigned int nTime, 
     }
     return false;
 }
-
-void WritePrimeNodeDB(); // Prototype
 
 // Inflate the primenode table in the primeNodeDB
 void InflatePrimeNodeDB(dbtype db) {

--- a/src/primenodes.h
+++ b/src/primenodes.h
@@ -7,6 +7,15 @@
 #include "db.h"
 #include "script.h"
 
+// Used for stake confirmation
+static const int64 MINIMUM_FOR_PRIMENODE_PHASE1 = 125000 * COIN;
+static const int64 MINIMUM_FOR_PRIMENODE_PHASE2 = 160000 * COIN;
+/* Used ONLY in wallet.cpp for stake generation checks (should always be set
+ * to the CURRENT MINIMUM_FOR_PRIMENODE) */
+static const int64 MINIMUM_FOR_PRIMENODE = MINIMUM_FOR_PRIMENODE_PHASE2;
+
+static const unsigned int END_PRIME_PHASE_ONE = 1435752000; // Wed, 01 Jul 2015 12:00:00 GMT
+
 bool initPrimeNodes(std::string &/*ret*/);
 void WritePrimeNodeDB();
 void WriteMicroPrimeDB();


### PR DESCRIPTION
Moves all primenode variable declarations that don't need to be in main.h
somewhere more appropriate.

This makes finding some of these declarations a little less obvious but that's what grep or spot are for IMHO. Personally I'd rather have to search these variables than have everything in main.h (it's nasty!).