### PR TITLE
Organise optionsdialog (split off Window and Network page) and add option to change language

### DIFF
--- a/src/qt/optionsdialog.cpp
+++ b/src/qt/optionsdialog.cpp
@@ -20,73 +20,96 @@
 #include <QRegExpValidator>
 #include <QDialogButtonBox>
 
-/* First page of options */
-class MainOptionsPage : public QWidget
+class OptionsPage: public QWidget
+{
+    Q_OBJECT
+public:
+    explicit OptionsPage(QWidget *parent=0): QWidget(parent) {}
+
+    virtual void setMapper(MonitoredDataMapper *mapper) = 0;
+};
+
+class MainOptionsPage: public OptionsPage
 {
     Q_OBJECT
 public:
     explicit MainOptionsPage(QWidget *parent=0);
 
-    void setMapper(MonitoredDataMapper *mapper);
+    virtual void setMapper(MonitoredDataMapper *mapper);
+private:
+    QCheckBox *detach_database;
+    BitcoinAmountField *fee_edit;
+};
+
+class WindowOptionsPage: public OptionsPage
+{
+    Q_OBJECT
+public:
+    explicit WindowOptionsPage(QWidget *parent=0);
+
+    virtual void setMapper(MonitoredDataMapper *mapper);
 private:
     QCheckBox *bitcoin_at_startup;
 #ifndef Q_OS_MAC
     QCheckBox *minimize_to_tray;
 #endif
-    QCheckBox *map_port_upnp;
 #ifndef Q_OS_MAC
     QCheckBox *minimize_on_close;
 #endif
-    QCheckBox *connect_socks4;
-    QCheckBox *detach_database;
-    QLineEdit *proxy_ip;
-    QLineEdit *proxy_port;
-    BitcoinAmountField *fee_edit;
-
-signals:
-
-public slots:
-
 };
 
-class DisplayOptionsPage : public QWidget
+class DisplayOptionsPage: public OptionsPage
 {
     Q_OBJECT
 public:
     explicit DisplayOptionsPage(QWidget *parent=0);
 
-    void setMapper(MonitoredDataMapper *mapper);
+    virtual void setMapper(MonitoredDataMapper *mapper);
 private:
     QValueComboBox *unit;
     QCheckBox *display_addresses;
     QCheckBox *coin_control_features;
-signals:
-
-public slots:
-
 };
+
+class NetworkOptionsPage: public OptionsPage
+{
+    Q_OBJECT
+public:
+    explicit NetworkOptionsPage(QWidget *parent=0);
+
+    virtual void setMapper(MonitoredDataMapper *mapper);
+private:
+    QCheckBox *map_port_upnp;
+    QCheckBox *connect_socks4;
+    QLineEdit *proxy_ip;
+    QLineEdit *proxy_port;
+};
+
 
 #include "optionsdialog.moc"
 
 OptionsDialog::OptionsDialog(QWidget *parent):
     QDialog(parent), contents_widget(0), pages_widget(0),
-    model(0), main_page(0), display_page(0)
+    model(0)
 {
     contents_widget = new QListWidget();
     contents_widget->setMaximumWidth(128);
 
     pages_widget = new QStackedWidget();
-    pages_widget->setMinimumWidth(300);
+    pages_widget->setMinimumWidth(500);
+    pages_widget->setMinimumHeight(300);
 
-    QListWidgetItem *item_main = new QListWidgetItem(tr("Main"));
-    contents_widget->addItem(item_main);
-    main_page = new MainOptionsPage(this);
-    pages_widget->addWidget(main_page);
+    pages.append(new MainOptionsPage(this));
+    pages.append(new NetworkOptionsPage(this));
+    pages.append(new WindowOptionsPage(this));
+    pages.append(new DisplayOptionsPage(this));
 
-    QListWidgetItem *item_display = new QListWidgetItem(tr("Display"));
-    contents_widget->addItem(item_display);
-    display_page = new DisplayOptionsPage(this);
-    pages_widget->addWidget(display_page);
+    foreach(OptionsPage *page, pages)
+    {
+        QListWidgetItem *item = new QListWidgetItem(page->windowTitle());
+        contents_widget->addItem(item);
+        pages_widget->addWidget(page);
+    }
 
     contents_widget->setCurrentRow(0);
 
@@ -126,8 +149,11 @@ void OptionsDialog::setModel(OptionsModel *model)
     this->model = model;
 
     mapper->setModel(model);
-    main_page->setMapper(mapper);
-    display_page->setMapper(mapper);
+
+    foreach(OptionsPage *page, pages)
+    {
+        page->setMapper(mapper);
+    }
 
     mapper->toFirst();
 }
@@ -164,10 +190,90 @@ void OptionsDialog::disableApply()
     apply_button->setEnabled(false);
 }
 
+/* Main options */
 MainOptionsPage::MainOptionsPage(QWidget *parent):
-        QWidget(parent)
+        OptionsPage(parent)
 {
     QVBoxLayout *layout = new QVBoxLayout();
+    setWindowTitle(tr("Main"));
+
+    QLabel *fee_help = new QLabel(tr("Optional transaction fee per kB that helps make sure your transactions are processed quickly. Most transactions are 1 kB. Fee 0.01 recommended."));
+    fee_help->setWordWrap(true);
+    layout->addWidget(fee_help);
+
+    QHBoxLayout *fee_hbox = new QHBoxLayout();
+    fee_hbox->addSpacing(18);
+    QLabel *fee_label = new QLabel(tr("Pay transaction &fee"));
+    fee_hbox->addWidget(fee_label);
+    fee_edit = new BitcoinAmountField();
+
+    fee_label->setBuddy(fee_edit);
+    fee_hbox->addWidget(fee_edit);
+    fee_hbox->addStretch(1);
+
+    layout->addLayout(fee_hbox);
+
+    detach_database = new QCheckBox(tr("Detach databases at shutdown"));
+    detach_database->setToolTip(tr("Detach block and address databases at shutdown. This means they can be moved to another data directory, but it slows down shutdown. The wallet is always detached."));
+    layout->addWidget(detach_database);
+
+    layout->addStretch(1); // Extra space at bottom
+    setLayout(layout);
+}
+
+void MainOptionsPage::setMapper(MonitoredDataMapper *mapper)
+{
+    // Map model to widgets
+    mapper->addMapping(fee_edit, OptionsModel::Fee);
+    mapper->addMapping(detach_database, OptionsModel::DetachDatabases);
+}
+
+/* Display options */
+DisplayOptionsPage::DisplayOptionsPage(QWidget *parent):
+        OptionsPage(parent)
+{
+    setWindowTitle(tr("Display"));
+
+    QVBoxLayout *layout = new QVBoxLayout();
+
+     QHBoxLayout *unit_hbox = new QHBoxLayout();
+     unit_hbox->addSpacing(18);
+     QLabel *unit_label = new QLabel(tr("&Unit to show amounts in: "));
+     unit_hbox->addWidget(unit_label);
+     unit = new QValueComboBox(this);
+     unit->setModel(new BitcoinUnits(this));
+     unit->setToolTip(tr("Choose the default subdivision unit to show in the interface, and when sending coins"));
+
+     unit_label->setBuddy(unit);
+     unit_hbox->addWidget(unit);
+
+     layout->addLayout(unit_hbox);
+
+     display_addresses = new QCheckBox(tr("&Display addresses in transaction list"), this);
+     display_addresses->setToolTip(tr("Whether to show Paycoin addresses in the transaction list"));
+     layout->addWidget(display_addresses);
+
+    coin_control_features = new QCheckBox(tr("Display coin control features (experts only!)"), this);
+    coin_control_features->setToolTip(tr("Whether to show coin control features or not"));
+    layout->addWidget(coin_control_features);
+
+     layout->addStretch();
+     setLayout(layout);
+ }
+
+ void DisplayOptionsPage::setMapper(MonitoredDataMapper *mapper)
+ {
+     mapper->addMapping(unit, OptionsModel::DisplayUnit);
+     mapper->addMapping(display_addresses, OptionsModel::DisplayAddresses);
+     mapper->addMapping(coin_control_features, OptionsModel::CoinControlFeatures);
+}
+
+/* Window options */
+WindowOptionsPage::WindowOptionsPage(QWidget *parent):
+        OptionsPage(parent)
+{
+    QVBoxLayout *layout = new QVBoxLayout();
+    setWindowTitle(tr("Window"));
 
     bitcoin_at_startup = new QCheckBox(tr("&Start Paycoin on window system startup"));
     bitcoin_at_startup->setToolTip(tr("Automatically start Paycoin after the computer is turned on"));
@@ -182,6 +288,29 @@ MainOptionsPage::MainOptionsPage(QWidget *parent):
     minimize_on_close->setToolTip(tr("Minimize instead of exit the application when the window is closed. When this option is enabled, the application will be closed only after selecting Quit in the menu."));
     layout->addWidget(minimize_on_close);
 #endif
+
+    layout->addStretch(1); // Extra space at bottom
+    setLayout(layout);
+}
+
+void WindowOptionsPage::setMapper(MonitoredDataMapper *mapper)
+{
+    // Map model to widgets
+    mapper->addMapping(bitcoin_at_startup, OptionsModel::StartAtStartup);
+#ifndef Q_OS_MAC
+    mapper->addMapping(minimize_to_tray, OptionsModel::MinimizeToTray);
+#endif
+#ifndef Q_OS_MAC
+    mapper->addMapping(minimize_on_close, OptionsModel::MinimizeOnClose);
+#endif
+}
+
+/* Network options */
+NetworkOptionsPage::NetworkOptionsPage(QWidget *parent):
+        OptionsPage(parent)
+{
+    QVBoxLayout *layout = new QVBoxLayout();
+    setWindowTitle(tr("Network"));
 
     map_port_upnp = new QCheckBox(tr("Map port using &UPnP"));
     map_port_upnp->setToolTip(tr("Automatically open the Paycoin client port on the router. This only works when your router supports UPnP and it is enabled."));
@@ -211,32 +340,10 @@ MainOptionsPage::MainOptionsPage(QWidget *parent):
     proxy_port->setToolTip(tr("Port of the proxy (e.g. 1234)"));
     proxy_port_label->setBuddy(proxy_port);
     proxy_hbox->addWidget(proxy_port);
-    proxy_hbox->addStretch(1);
 
     layout->addLayout(proxy_hbox);
-    QLabel *fee_help = new QLabel(tr("Mandatory network transaction fee per kB transferred. Most transactions are 1 kB and incur a 0.01 XPY fee. Note: transfer size may increase depending on the number of input transactions required to be added together to fund the payment."));
-    fee_help->setWordWrap(true);
-    layout->addWidget(fee_help);
-
-    QHBoxLayout *fee_hbox = new QHBoxLayout();
-    fee_hbox->addSpacing(18);
-    QLabel *fee_label = new QLabel(tr("Additional network &fee:"));
-    fee_hbox->addWidget(fee_label);
-    fee_edit = new BitcoinAmountField();
-    fee_edit->setDisabled(true);
-
-    fee_label->setBuddy(fee_edit);
-    fee_hbox->addWidget(fee_edit);
-    fee_hbox->addStretch(1);
-
-    layout->addLayout(fee_hbox);
-
-    detach_database = new QCheckBox(tr("Detach databases at shutdown"));
-    detach_database->setToolTip(tr("Detach block and address databases at shutdown. This means they can be moved to another data directory, but it slows down shutdown. The wallet is always detached."));
-    layout->addWidget(detach_database);
 
     layout->addStretch(1); // Extra space at bottom
-
     setLayout(layout);
 
     connect(connect_socks4, SIGNAL(toggled(bool)), proxy_ip, SLOT(setEnabled(bool)));
@@ -247,58 +354,11 @@ MainOptionsPage::MainOptionsPage(QWidget *parent):
 #endif
 }
 
-void MainOptionsPage::setMapper(MonitoredDataMapper *mapper)
+void NetworkOptionsPage::setMapper(MonitoredDataMapper *mapper)
 {
     // Map model to widgets
-    mapper->addMapping(bitcoin_at_startup, OptionsModel::StartAtStartup);
-#ifndef Q_OS_MAC
-    mapper->addMapping(minimize_to_tray, OptionsModel::MinimizeToTray);
-#endif
     mapper->addMapping(map_port_upnp, OptionsModel::MapPortUPnP);
-#ifndef Q_OS_MAC
-    mapper->addMapping(minimize_on_close, OptionsModel::MinimizeOnClose);
-#endif
     mapper->addMapping(connect_socks4, OptionsModel::ConnectSOCKS4);
     mapper->addMapping(proxy_ip, OptionsModel::ProxyIP);
     mapper->addMapping(proxy_port, OptionsModel::ProxyPort);
-    mapper->addMapping(fee_edit, OptionsModel::Fee);
-    mapper->addMapping(detach_database, OptionsModel::DetachDatabases);
-}
-
-DisplayOptionsPage::DisplayOptionsPage(QWidget *parent):
-        QWidget(parent)
-{
-    QVBoxLayout *layout = new QVBoxLayout();
-
-    QHBoxLayout *unit_hbox = new QHBoxLayout();
-    unit_hbox->addSpacing(18);
-    QLabel *unit_label = new QLabel(tr("&Unit to show amounts in: "));
-    unit_hbox->addWidget(unit_label);
-    unit = new QValueComboBox(this);
-    unit->setModel(new BitcoinUnits(this));
-    unit->setToolTip(tr("Choose the default subdivision unit to show in the interface, and when sending coins"));
-
-    unit_label->setBuddy(unit);
-    unit_hbox->addWidget(unit);
-
-    layout->addLayout(unit_hbox);
-
-    display_addresses = new QCheckBox(tr("&Display addresses in transaction list"), this);
-    display_addresses->setToolTip(tr("Whether to show Paycoin addresses in the transaction list"));
-    layout->addWidget(display_addresses);
-
-    coin_control_features = new QCheckBox(tr("Display coin control features (experts only!)"), this);
-    coin_control_features->setToolTip(tr("Whether to show coin control features or not"));
-    layout->addWidget(coin_control_features);
-
-    layout->addStretch();
-
-    setLayout(layout);
-}
-
-void DisplayOptionsPage::setMapper(MonitoredDataMapper *mapper)
-{
-    mapper->addMapping(unit, OptionsModel::DisplayUnit);
-    mapper->addMapping(display_addresses, OptionsModel::DisplayAddresses);
-    mapper->addMapping(coin_control_features, OptionsModel::CoinControlFeatures);
 }

--- a/src/qt/optionsdialog.h
+++ b/src/qt/optionsdialog.h
@@ -2,6 +2,7 @@
 #define OPTIONSDIALOG_H
 
 #include <QDialog>
+#include <QList>
 
 QT_BEGIN_NAMESPACE
 class QStackedWidget;
@@ -10,8 +11,7 @@ class QListWidgetItem;
 class QPushButton;
 QT_END_NAMESPACE
 class OptionsModel;
-class MainOptionsPage;
-class DisplayOptionsPage;
+class OptionsPage;
 class MonitoredDataMapper;
 
 /** Preferences dialog. */
@@ -43,11 +43,7 @@ private:
     MonitoredDataMapper *mapper;
     QPushButton *apply_button;
 
-    // Pages
-    MainOptionsPage *main_page;
-    DisplayOptionsPage *display_page;
-
-    void setupMainPage();
+    QList<OptionsPage*> pages;
 };
 
 #endif // OPTIONSDIALOG_H

--- a/src/qt/optionsmodel.cpp
+++ b/src/qt/optionsmodel.cpp
@@ -22,6 +22,7 @@ void OptionsModel::Init()
     fMinimizeOnClose = settings.value("fMinimizeOnClose", false).toBool();
     nTransactionFee = settings.value("nTransactionFee").toLongLong();
     fCoinControlFeatures = settings.value("fCoinControlFeatures", false).toBool();
+    language = settings.value("language", "").toString();
 
     // These are shared with core bitcoin; we want
     // command-line options to override the GUI settings:
@@ -31,6 +32,8 @@ void OptionsModel::Init()
         SoftSetArg("-proxy", settings.value("addrProxy").toString().toStdString());
     if (settings.contains("detachDB"))
         SoftSetBoolArg("-detachdb", settings.value("detachDB").toBool());
+    if (!language.isEmpty())
+        SoftSetArg("-lang", language.toStdString());
 }
 
 bool OptionsModel::Upgrade()
@@ -128,6 +131,8 @@ QVariant OptionsModel::data(const QModelIndex & index, int role) const
             return QVariant(bitdb.GetDetached());
         case CoinControlFeatures:
             return QVariant(fCoinControlFeatures);
+        case Language:
+            return settings.value("language", "");
         default:
             return QVariant();
         }
@@ -221,6 +226,10 @@ bool OptionsModel::setData(const QModelIndex & index, const QVariant & value, in
             fCoinControlFeatures = value.toBool();
             settings.setValue("fCoinControlFeatures", fCoinControlFeatures);
             emit coinControlFeaturesChanged(fCoinControlFeatures);
+            }
+            break;
+        case Language: {
+            settings.setValue("language", value);
             }
             break;
         default:

--- a/src/qt/optionsmodel.h
+++ b/src/qt/optionsmodel.h
@@ -28,6 +28,7 @@ public:
         DisplayAddresses, // bool
         DetachDatabases, // bool
         CoinControlFeatures, // bool
+        Language, // QString
         OptionIDRowCount,
     };
 
@@ -47,14 +48,14 @@ public:
     int getDisplayUnit() { return nDisplayUnit; }
     bool getDisplayAddresses() { return bDisplayAddresses; }
     bool getCoinControlFeatures();
-
+    QString getLanguage() { return language; }
 private:
     int nDisplayUnit;
     bool bDisplayAddresses;
     bool fMinimizeToTray;
     bool fMinimizeOnClose;
     bool fCoinControlFeatures;
-
+    QString language;
 signals:
     void displayUnitChanged(int unit);
     void transactionFeeChanged(qint64);

--- a/src/qt/qvaluecombobox.cpp
+++ b/src/qt/qvaluecombobox.cpp
@@ -6,12 +6,12 @@ QValueComboBox::QValueComboBox(QWidget *parent) :
     connect(this, SIGNAL(currentIndexChanged(int)), this, SLOT(handleSelectionChanged(int)));
 }
 
-int QValueComboBox::value() const
+QVariant QValueComboBox::value() const
 {
-    return itemData(currentIndex(), role).toInt();
+    return itemData(currentIndex(), role);
 }
 
-void QValueComboBox::setValue(int value)
+void QValueComboBox::setValue(const QVariant &value)
 {
     setCurrentIndex(findData(value, role));
 }

--- a/src/qt/qvaluecombobox.h
+++ b/src/qt/qvaluecombobox.h
@@ -2,19 +2,20 @@
 #define QVALUECOMBOBOX_H
 
 #include <QComboBox>
+#include <QVariant>
 
 /* QComboBox that can be used with QDataWidgetMapper to select ordinal values from a model. */
 class QValueComboBox : public QComboBox
 {
     Q_OBJECT
-    Q_PROPERTY(int value READ value WRITE setValue NOTIFY valueChanged USER true)
+    Q_PROPERTY(QVariant value READ value WRITE setValue NOTIFY valueChanged USER true)
 public:
     explicit QValueComboBox(QWidget *parent = 0);
 
-    int value() const;
-    void setValue(int value);
+    QVariant value() const;
+    void setValue(const QVariant &value);
 
-    /** Specify model role to use as ordinal value */
+    /** Specify model role to use as ordinal value (defaults to Qt::UserRole) */
     void setRole(int role);
 
 signals:


### PR DESCRIPTION
The options dialog crammed too many items into the main page. This pull request organises the options into four pages which are clearly different categories: Main, Network, Window and Display.

It also adds an option to change the language.

Bitcoin references:
https://github.com/bitcoin/bitcoin/commit/6ddf861078e465dcb89e14e8cad6229c7abf64bb
https://github.com/bitcoin/bitcoin/commit/5ac114c7566b7d3aa32b93124ccb5e5e364edc25