### PR TITLE
Bugfix messagestart

### DIFF
--- a/src/db.cpp
+++ b/src/db.cpp
@@ -11,6 +11,7 @@
 #include "util.h"
 #include "main.h"
 #include "kernel.h"
+#include "protocol.h"
 #include <boost/version.hpp>
 #include <boost/filesystem.hpp>
 #include <boost/filesystem/fstream.hpp>
@@ -855,6 +856,8 @@ bool CAddrDB::Write(const CAddrMan& addr)
 
     // serialize addresses, checksum data up to that point, then append csum
     CDataStream ssPeers(SER_DISK, CLIENT_VERSION);
+    unsigned char pchMessageStart[4];
+    GetMessageStart(pchMessageStart);
     ssPeers << FLATDATA(pchMessageStart);
     ssPeers << addr;
     uint256 hash = Hash(ssPeers.begin(), ssPeers.end());
@@ -927,6 +930,8 @@ bool CAddrDB::Read(CAddrMan& addr)
     }
 
     // finally, verify the network matches ours
+    unsigned char pchMessageStart[4];
+    GetMessageStart(pchMessageStart);
     if (memcmp(pchMsgTmp, pchMessageStart, sizeof(pchMsgTmp)))
         return error("CAddrman::Read() : invalid network magic number");
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2708,11 +2708,6 @@ bool static AlreadyHave(CTxDB& txdb, const CInv& inv)
     return true;
 }
 
-// The message start string is designed to be unlikely to occur in normal data.
-// The characters are rarely used upper ascii, not valid as UTF-8, and produce
-// a large 4-byte int at any alignment.
-unsigned char pchMessageStart[4] = { 0xf9, 0xbe, 0xb4, 0xd9 };
-
 bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv)
 {
     RandAddSeedPerfmon();

--- a/src/main.h
+++ b/src/main.h
@@ -1032,7 +1032,7 @@ public:
 
         // Write index header
         unsigned char pchMessageStart[4];
-        GetMessageStart(pchMessageStart, true);
+        GetMessageStart(pchMessageStart);
         unsigned int nSize = fileout.GetSerializeSize(*this);
         fileout << FLATDATA(pchMessageStart) << nSize;
 

--- a/src/main.h
+++ b/src/main.h
@@ -98,7 +98,6 @@ extern int64 nTimeBestReceived;
 extern CCriticalSection cs_setpwalletRegistered;
 extern std::set<CWallet*> setpwalletRegistered;
 extern std::map<uint256, CBlock*> mapOrphanBlocks;
-extern unsigned char pchMessageStart[4];
 
 // Settings
 extern int64 nTransactionFee;

--- a/src/protocol.cpp
+++ b/src/protocol.cpp
@@ -20,7 +20,7 @@ static unsigned char pchMessageStartMain[4] = { 0xaa, 0xaa, 0xaa, 0xaa };
 // Public testnet message start
 static unsigned char pchMessageStartTest[4] = { 0xbb, 0xbb, 0xbb, 0xbb };
 
-void GetMessageStart(unsigned char pchMessageStart[], bool fPersistent)
+void GetMessageStart(unsigned char pchMessageStart[])
 {
     if (fTestNet)
         memcpy(pchMessageStart, pchMessageStartTest, sizeof(pchMessageStartTest));

--- a/src/protocol.h
+++ b/src/protocol.h
@@ -22,7 +22,7 @@
 
 extern bool fTestNet;
 
-void GetMessageStart(unsigned char pchMessageStart[], bool fPersistent = false);
+void GetMessageStart(unsigned char pchMessageStart[]);
 
 static inline unsigned short GetDefaultPort(const bool testnet = fTestNet)
 {


### PR DESCRIPTION
Unfortunately I've all but ruled this out as the cause of the fork issues:
NONE of the debug logs I've looked at from a forked node have the error that would show if this was causing an issue and as it stands the "bad" start message isn't being sent anywhere but needs to be corrected anyway for obvious reasons.