### PR TITLE
Add a '-stake' flag to disable the staking thread

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -312,7 +312,8 @@ bool AppInit2(int argc, char* argv[])
             "  -keypool=<n>     \t  "   + _("Set key pool size to <n> (default: 100)") + "\n" +
             "  -rescan          \t  "   + _("Rescan the block chain for missing wallet transactions") + "\n" +
             "  -checkblocks=<n> \t\t  " + _("How many blocks to check at startup (default: 2500, 0 = all)") + "\n" +
-            "  -checklevel=<n>  \t\t  " + _("How thorough the block verification is (0-6, default: 1)") + "\n";
+            "  -checklevel=<n>  \t\t  " + _("How thorough the block verification is (0-6, default: 1)") + "\n" +
+            "  -stake           \t\t  " + _("Set whether the node should stake (default: 1)") + "\n";
 
         strUsage += string() +
             _("\nSSL options: (see the Paycoin Wiki for SSL setup instructions)") + "\n" +
@@ -744,6 +745,10 @@ bool AppInit2(int argc, char* argv[])
         if (!Checkpoints::SetCheckpointPrivKey(GetArg("-checkpointkey", "")))
             return InitError(_("Unable to sign checkpoint, wrong checkpointkey?"));
     }
+
+    // Set stake to true if it's not set in the conf
+    if (!mapArgs.count("-stake"))
+        SoftSetBoolArg("-stake", true);
 
     //
     // Start the node

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2579,6 +2579,12 @@ string GetWarnings(string strFor)
     if (GetBoolArg("-testsafemode"))
         strRPC = "test";
 
+    if (!GetBoolArg("-stake", true))
+    {
+        nPriority = 0;
+        strStatusBar = "Info: Minting is currently disabled.";
+    }
+
     // paycoin: wallet lock warning for minting
     if (strMintWarning != "")
     {

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -1907,8 +1907,12 @@ void StartNode(void* parg)
     GenerateBitcoins(GetBoolArg("-gen", false), pwalletMain);
 
     // paycoin: mint proof-of-stake blocks in the background
-    if (!NewThread(ThreadStakeMinter, pwalletMain))
-        printf("Error: NewThread(ThreadStakeMinter) failed\n");
+    // Don't run the thread if staking is disabled (no need to waste resources)
+    if (!GetBoolArg("-stake", true))
+        printf("Staking disabled\n");
+    else
+        if (!NewThread(ThreadStakeMinter, pwalletMain))
+            printf("Error: NewThread(ThreadStakeMinter) failed\n");
 }
 
 bool StopNode()


### PR DESCRIPTION
Default value is 1 (staking enabled)
When set to 0 either by command line or conf file the staking thread is never started.

This is handy for machines being used purely as dnsseeds or block explorer wallets to
reduce the CPU overhead of the wallet itself.