### PR TITLE
Upgrade OpenSSL to 1.0.1h

### DIFF
--- a/contrib/gitian-descriptors/deps-linux.yml
+++ b/contrib/gitian-descriptors/deps-linux.yml
@@ -16,7 +16,7 @@ packages:
 reference_datetime: "2013-06-01 00:00:00"
 remotes: []
 files:
-- "openssl-1.0.1g.tar.gz"
+- "openssl-1.0.1h.tar.gz"
 - "miniupnpc-1.9.tar.gz"
 - "qrencode-3.4.3.tar.bz2"
 - "db-4.8.30.NC.tar.gz"
@@ -29,14 +29,14 @@ script: |
   export TZ=UTC
   export LIBRARY_PATH="$STAGING/lib"
   # Integrity Check
-  echo "53cb818c3b90e507a8348f4f5eaedb05d8bfe5358aabb508b7263cc670c3e028  openssl-1.0.1g.tar.gz"  | sha256sum -c
+  echo "9d1c8a9836aa63e2c6adb684186cbd4371c9e9dcc01d6e3bb447abf2d4d3d093  openssl-1.0.1h.tar.gz"  | sha256sum -c
   echo "2923e453e880bb949e3d4da9f83dd3cb6f08946d35de0b864d0339cf70934464  miniupnpc-1.9.tar.gz"   | sha256sum -c
   echo "dfd71487513c871bad485806bfd1fdb304dedc84d2b01a8fb8e0940b50597a98  qrencode-3.4.3.tar.bz2" | sha256sum -c
   echo "12edc0df75bf9abd7f82f821795bcee50f42cb2e5f76a6a281b85732798364ef  db-4.8.30.NC.tar.gz"    | sha256sum -c
 
   #
-  tar xzf openssl-1.0.1g.tar.gz
-  cd openssl-1.0.1g
+  tar xzf openssl-1.0.1h.tar.gz
+  cd openssl-1.0.1h
   #   need -fPIC to avoid relocation error in 64 bit builds
   ./config no-shared no-zlib no-dso no-krb5 --openssldir=$STAGING -fPIC
   #   need to build OpenSSL with faketime because a timestamp is embedded into cversion.o
@@ -81,4 +81,4 @@ script: |
   done
   #
   cd $STAGING
-  find include lib bin host | sort | zip -X@ $OUTDIR/paycoin-deps-linux${GBUILD_BITS}-gitian-r5.zip
+  find include lib bin host | sort | zip -X@ $OUTDIR/paycoin-deps-linux${GBUILD_BITS}-gitian-r6.zip

--- a/contrib/gitian-descriptors/deps-win.yml
+++ b/contrib/gitian-descriptors/deps-win.yml
@@ -14,7 +14,7 @@ packages:
 reference_datetime: "2011-01-30 00:00:00"
 remotes: []
 files:
-- "openssl-1.0.1g.tar.gz"
+- "openssl-1.0.1h.tar.gz"
 - "db-4.8.30.NC.tar.gz"
 - "miniupnpc-1.9.tar.gz"
 - "zlib-1.2.8.tar.gz"
@@ -28,7 +28,7 @@ script: |
   INDIR=$HOME/build
   TEMPDIR=$HOME/tmp
   # Input Integrity Check
-  echo "53cb818c3b90e507a8348f4f5eaedb05d8bfe5358aabb508b7263cc670c3e028  openssl-1.0.1g.tar.gz"  | sha256sum -c
+  echo "9d1c8a9836aa63e2c6adb684186cbd4371c9e9dcc01d6e3bb447abf2d4d3d093  openssl-1.0.1h.tar.gz"  | sha256sum -c
   echo "12edc0df75bf9abd7f82f821795bcee50f42cb2e5f76a6a281b85732798364ef  db-4.8.30.NC.tar.gz"    | sha256sum -c
   echo "2923e453e880bb949e3d4da9f83dd3cb6f08946d35de0b864d0339cf70934464  miniupnpc-1.9.tar.gz"   | sha256sum -c
   echo "36658cb768a54c1d4dec43c3116c27ed893e88b02ecfcb44f2166f9c0b7f2a0d  zlib-1.2.8.tar.gz"      | sha256sum -c
@@ -48,8 +48,8 @@ script: |
     mkdir -p $INSTALLPREFIX $BUILDDIR
     cd $BUILDDIR
     #
-    tar xzf $INDIR/openssl-1.0.1g.tar.gz
-    cd openssl-1.0.1g
+    tar xzf $INDIR/openssl-1.0.1h.tar.gz
+    cd openssl-1.0.1h
     if [ "$BITS" == "32" ]; then
       OPENSSL_TGT=mingw
     else
@@ -73,16 +73,16 @@ script: |
   --- miniupnpc-1.9/Makefile.mingw.orig   2013-09-29 18:52:51.014087958 -1000
   +++ miniupnpc-1.9/Makefile.mingw        2013-09-29 19:09:29.663318691 -1000
   @@ -67,8 +67,8 @@
-   
+
    wingenminiupnpcstrings.o:	wingenminiupnpcstrings.c
-   
+
   -miniupnpcstrings.h: miniupnpcstrings.h.in wingenminiupnpcstrings
   -	wingenminiupnpcstrings \$< \$@
   +miniupnpcstrings.h: miniupnpcstrings.h.in
   +	sed -e 's|OS/version|MSWindows/5.1.2600|' -e 's|MINIUPNPC_VERSION_STRING \"version\"|MINIUPNPC_VERSION_STRING \"VERSIONHERE\"|' \$< > \$@
-   
+
    minixml.o:	minixml.c minixml.h miniupnpcstrings.h
-   
+
   " | sed "s/VERSIONHERE/$(cat VERSION)/" | patch -p1
     mkdir -p dll
     make -f Makefile.mingw CC=$HOST-gcc AR=$HOST-ar libminiupnpc.a
@@ -124,5 +124,5 @@ script: |
     done
     #
     cd $INSTALLPREFIX
-    find include lib | sort | zip -X@ $OUTDIR/paycoin-deps-win$BITS-gitian-r12.zip
+    find include lib | sort | zip -X@ $OUTDIR/paycoin-deps-win$BITS-gitian-r13.zip
   done # for BITS in

--- a/contrib/gitian-descriptors/gitian-linux.yml
+++ b/contrib/gitian-descriptors/gitian-linux.yml
@@ -19,8 +19,8 @@ remotes:
 - "url": "https://github.com/paycoinfoundation/paycoin.git"
   "dir": "paycoin"
 files:
-- "paycoin-deps-linux32-gitian-r5.zip"
-- "paycoin-deps-linux64-gitian-r5.zip"
+- "paycoin-deps-linux32-gitian-r6.zip"
+- "paycoin-deps-linux64-gitian-r6.zip"
 - "boost-linux32-1.55.0-gitian-r1.zip"
 - "boost-linux64-1.55.0-gitian-r1.zip"
 script: |
@@ -35,7 +35,7 @@ script: |
   #
   mkdir -p $STAGING
   cd $STAGING
-  unzip ../build/paycoin-deps-linux${GBUILD_BITS}-gitian-r5.zip
+  unzip ../build/paycoin-deps-linux${GBUILD_BITS}-gitian-r6.zip
   unzip ../build/boost-linux${GBUILD_BITS}-1.55.0-gitian-r1.zip
   cd ..
   #

--- a/contrib/gitian-descriptors/gitian-win.yml
+++ b/contrib/gitian-descriptors/gitian-win.yml
@@ -21,8 +21,8 @@ files:
 - "qt-win64-4.8.5-gitian-r3.zip"
 - "boost-win32-1.55.0-gitian-r6.zip"
 - "boost-win64-1.55.0-gitian-r6.zip"
-- "paycoin-deps-win32-gitian-r12.zip"
-- "paycoin-deps-win64-gitian-r12.zip"
+- "paycoin-deps-win32-gitian-r13.zip"
+- "paycoin-deps-win64-gitian-r13.zip"
 script: |
   # Defines
   export TZ=UTC
@@ -46,7 +46,7 @@ script: |
     cd $STAGING
     unzip $INDIR/qt-win${BITS}-4.8.5-gitian-r3.zip
     unzip $INDIR/boost-win${BITS}-1.55.0-gitian-r6.zip
-    unzip $INDIR/paycoin-deps-win${BITS}-gitian-r12.zip
+    unzip $INDIR/paycoin-deps-win${BITS}-gitian-r13.zip
     if [ "$NEEDDIST" == "1" ]; then
       # Make source code archive which is architecture independent so it only needs to be done once
       cd $HOME/build/paycoin

--- a/doc/build-msw.md
+++ b/doc/build-msw.md
@@ -24,7 +24,7 @@ Dependencies
 Libraries you need to download separately and build:
 
                 default path               download
-OpenSSL         \openssl-1.0.1g-mgw        https://www.openssl.org/source/
+OpenSSL         \openssl-1.0.1h-mgw        https://www.openssl.org/source/
 Berkeley DB     \db-4.8.30.NC-mgw          https://www.oracle.com/technology/software/products/berkeley-db/index.html
 Boost           \boost-1.47.0-mgw          http://www.boost.org/users/download/
 miniupnpc       \miniupnpc-1.6-mgw         http://miniupnp.tuxfamily.org/files/
@@ -36,7 +36,7 @@ Boost          MIT-like license
 miniupnpc      New (3-clause) BSD license
 
 Versions used in this release:
-OpenSSL      1.0.1g
+OpenSSL      1.0.1h
 Berkeley DB  4.8.30.NC
 Boost        1.47.0
 miniupnpc    1.6
@@ -48,7 +48,7 @@ MSYS shell:
 un-tar sources with MSYS 'tar xfz' to avoid issue with symlinks (OpenSSL ticket 2377)
 change 'MAKE' env. variable from 'C:\MinGW32\bin\mingw32-make.exe' to '/c/MinGW32/bin/mingw32-make.exe'
 
-cd /c/openssl-1.0.1g-mgw
+cd /c/openssl-1.0.1h-mgw
 ./config
 make
 

--- a/doc/build-unix.md
+++ b/doc/build-unix.md
@@ -54,7 +54,7 @@ Licenses of statically linked libraries:
 
 Versions used in this release:
  GCC           4.3.3
- OpenSSL       1.0.1g
+ OpenSSL       1.0.1h
  Berkeley DB   4.8.30.NC
  Boost         1.37
  miniupnpc     1.6
@@ -75,12 +75,12 @@ If using Boost 1.37, append -mt to the boost libraries in the makefile.
 Dependency Build Instructions: Gentoo
 -------------------------------------
 
-Note: Currently, there is no paycoin ebuild available in overlay 
+Note: Currently, there is no paycoin ebuild available in overlay
 
 emerge -av1 --noreplace dev-libs/boost dev-libs/glib dev-libs/openssl sys-libs/db:4.8
 
 Note: If you like to have UPnP support, you need to install net-libs/miniupnpc.
- 
+
 Take the following steps to build (no UPnP support):
  cd paycoin/src
  make -f makefile.unix USE_UPNP= BDB_INCLUDE_PATH='/usr/include/db4.8'

--- a/doc/release-process.md
+++ b/doc/release-process.md
@@ -25,7 +25,7 @@ Release Process
 ### Perform gitian builds
 
 From a directory containing the paycoin source, gitian-builder and gitian.sigs
- 
+
 	export SIGNER=(your gitian key, ie bluematt, sipa, etc)
 	export VERSION=(new version, e.g. 0.8.0)
 	cd ~/gitian-builder
@@ -33,7 +33,7 @@ From a directory containing the paycoin source, gitian-builder and gitian.sigs
 ### Fetch and build inputs:
 	mkdir -p inputs; cd inputs/
 	wget 'http://miniupnp.free.fr/files/download.php?file=miniupnpc-1.9.tar.gz' -O miniupnpc-1.9.tar.gz
-	wget 'https://www.openssl.org/source/openssl-1.0.1g.tar.gz'
+	wget 'https://www.openssl.org/source/openssl-1.0.1h.tar.gz'
 	wget 'http://download.oracle.com/berkeley-db/db-4.8.30.NC.tar.gz'
 	wget 'http://zlib.net/zlib-1.2.8.tar.gz'
 	wget 'ftp://ftp.simplesystems.org/pub/png/src/history/libpng16/libpng-1.6.8.tar.gz'
@@ -72,7 +72,7 @@ From a directory containing the paycoin source, gitian-builder and gitian.sigs
 	mv paycoin-${VERSION}-win-gitian.zip ../../
 	popd
 Build output expected:
-  
+
 1. linux 32-bit and 64-bit binaries + source (paycoin-${VERSION}-linux-gitian.zip)
 2. windows 32-bit and 64-bit binaries, installers + source (paycoin-${VERSION}-win-gitian.zip)
 3. Gitian signatures (in gitian.sigs/${VERSION}[-win]/(your gitian key)/
@@ -126,7 +126,7 @@ Build output expected: Paycoin-Qt.dmg
 * Update wiki changelog
 
 * Commit your signature to gitian.sigs:
-  
+
     pushd gitian.sigs
 	git add ${VERSION}/${SIGNER}
 	git add ${VERSION}-win/${SIGNER}

--- a/src/makefile.mingw
+++ b/src/makefile.mingw
@@ -10,9 +10,9 @@
 #
 # - Add/edit 'MAKE' environment variable with value '/c/MinGW32/bin/mingw32-make.exe'
 #
-# - Build openssl library version: 1.0.1g
+# - Build openssl library version: 1.0.1h
 #   download from  https://www.openssl.org/source/
-#   Extract to c:\openssl-1.0.1g-mgw
+#   Extract to c:\openssl-1.0.1h-mgw
 #   In MinGW MSYS:
 #     ./config
 #     make
@@ -64,12 +64,12 @@ USE_UPNP:=0
 INCLUDEPATHS= \
  -I"C:\boost-1.47.0-mgw" \
  -I"C:\db-4.8.30.NC-mgw\build_unix" \
- -I"C:\openssl-1.0.1g-mgw\include"
+ -I"C:\openssl-1.0.1h-mgw\include"
 
 LIBPATHS= \
  -L"C:\boost-1.47.0-mgw\stage\lib" \
  -L"C:\db-4.8.30.NC-mgw\build_unix" \
- -L"C:\openssl-1.0.1g-mgw"
+ -L"C:\openssl-1.0.1h-mgw"
 
 LIBS= \
  -l boost_system-mgw46-mt-s-1_47 \


### PR DESCRIPTION
Upgrade for https://www.openssl.org/news/secadv/20140605.txt

First: there is no vulnerability that affects ecdsa signing or verification. However, the MITM attack vulnerability (CVE-2014-0224) may have some effect on our usage of SSL/TLS.

As long as payment requests are signed (which is the common case), usage of the payment protocol should also not be affected.

The TLS usage in RPC may be at risk for MITM attacks. If you have -rpcssl enabled, be sure to update OpenSSL as soon as possible.

Reference:
https://github.com/bitcoin/bitcoin/commit/6e7c4d17d8abb4b1c8b91504699ce6970e01a1fb