### PR TITLE
Qt: small header changes / fixes

### DIFF
--- a/src/qt/addressbookpage.h
+++ b/src/qt/addressbookpage.h
@@ -69,4 +69,4 @@ private slots:
     void onEditAction();
 };
 
-#endif // ADDRESSBOOKDIALOG_H
+#endif // ADDRESSBOOKPAGE_H

--- a/src/qt/bitcoinamountfield.h
+++ b/src/qt/bitcoinamountfield.h
@@ -1,5 +1,5 @@
-#ifndef BITCOINFIELD_H
-#define BITCOINFIELD_H
+#ifndef BITCOINAMOUNTFIELD_H
+#define BITCOINAMOUNTFIELD_H
 
 #include <QWidget>
 
@@ -57,4 +57,4 @@ private slots:
 };
 
 
-#endif // BITCOINFIELD_H
+#endif // BITCOINAMOUNTFIELD_H

--- a/src/qt/bitcoingui.h
+++ b/src/qt/bitcoingui.h
@@ -185,4 +185,4 @@ private slots:
     void toggleHidden();
 };
 
-#endif
+#endif // BITCOINGUI_H

--- a/src/qt/qtipcserver.h
+++ b/src/qt/qtipcserver.h
@@ -1,4 +1,10 @@
+#ifndef QTIPCSERVER_H
+#define QTIPCSERVER_H
+
+// Define Bitcoin-Qt message queue name
 #define BITCOINURI_QUEUE_NAME "BitcoinURI"
 
 void ipcInit();
 void ipcShutdown();
+
+#endif // QTIPCSERVER_H

--- a/src/qt/transactiontablemodel.h
+++ b/src/qt/transactiontablemodel.h
@@ -79,5 +79,4 @@ private slots:
     friend class TransactionTablePriv;
 };
 
-#endif
-
+#endif // TRANSACTIONTABLEMODEL_H


### PR DESCRIPTION
- ensure header inclusion guard is named after the header file
- add missing comments at the end of some inclusion guards

Reference:
https://github.com/bitcoin/bitcoin/commit/128eefa0f88ff80c5d6398d13e25a3f4df96081a