### PR TITLE
Don't stop users from using 0.0.0.0 as the a bind address

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -695,7 +695,7 @@ bool AppInit2(int argc, char* argv[])
         if (mapArgs.count("-bind")) {
             BOOST_FOREACH(std::string strBind, mapMultiArgs["-bind"]) {
                 CService addrBind(strBind, GetListenPort(), false);
-                if (!addrBind.IsValid())
+                if (!addrBind.IsValid(true))
                     return InitError(strprintf(_("Cannot resolve -bind address: '%s'"), strBind.c_str()));
 
                 fBound |= Bind(addrBind);

--- a/src/netbase.cpp
+++ b/src/netbase.cpp
@@ -647,7 +647,7 @@ bool CNetAddr::IsMulticast() const
            || (GetByte(15) == 0xFF);
 }
 
-bool CNetAddr::IsValid() const
+bool CNetAddr::IsValid(bool isinit) const
 {
     // Cleanup 3-byte shifted addresses caused by garbage in size field
     // of addr messages from versions before 0.2.9 checksum.
@@ -674,9 +674,15 @@ bool CNetAddr::IsValid() const
         if (memcmp(ip+12, &ipNone, 4) == 0)
             return false;
 
-        // 0
+        /* All 0 addresses (shorter than 0.0.0.0) are automatically corrected by
+         * BindListenPort; IE: 0, 0.0 and 0.0.0 all result in an address of
+         * 0.0.0.0. While anything longer is not considered IPv4 anyway.
+         * Though this is the default there's also no reason to block it
+         * from being used either, except for existing routable/reachable
+         * checks. Check if this is init and if so don't return false as 0 is
+         * valid (default in fact) in such an instance. */
         ipNone = 0;
-        if (memcmp(ip+12, &ipNone, 4) == 0)
+        if (memcmp(ip+12, &ipNone, 4) == 0 && !isinit)
             return false;
     }
 

--- a/src/netbase.h
+++ b/src/netbase.h
@@ -60,7 +60,7 @@ class CNetAddr
         bool IsGarliCat() const;
         bool IsLocal() const;
         bool IsRoutable() const;
-        bool IsValid() const;
+        bool IsValid(bool isinit = false) const;
         bool IsMulticast() const;
         enum Network GetNetwork() const;
         std::string ToString() const;


### PR DESCRIPTION
While 0.0.0.0 is already the default bind address for IPv4 blocking
it breaks old conf files that are configured using this.

Instead of removing the IsValid check on bind addresses don't check
if the address is a 0 address during init (allow other IsValid checks
to function as they always have).

0, 0.0 and 0.0.0 addresses are all expanded to 0.0.0.0 (confirmed by
printing to string during tests) while anything longer is obviously
not an IPv4 address and should be checked like normal.