### PR TITLE
Better validity checks for scrape addresses

### DIFF
--- a/src/bitcoinrpc.h
+++ b/src/bitcoinrpc.h
@@ -26,6 +26,9 @@ json_spirit::Object JSONRPCError(int code, const std::string& message);
 /** Convert parameter values for RPC call from strings to command-specific JSON objects. */
 json_spirit::Array RPCConvertValues(const std::string &strMethod, const std::vector<std::string> &strParams);
 
+/** Call the RPC service directly (placed here to allow for more in depth tests.) */
+json_spirit::Object CallRPC(const std::string& strMethod, const json_spirit::Array& params);
+
 /** Convert unsigned integer/s to hex string */
 std::string HexBits(unsigned int nBits);
 

--- a/src/qt/addresstablemodel.cpp
+++ b/src/qt/addresstablemodel.cpp
@@ -220,6 +220,12 @@ bool AddressTableModel::setData(const QModelIndex & index, const QVariant & valu
             if (rec->type == AddressTableEntry::Sending)
                 break;
 
+            /* Require authentication when modifying a scrape address on an
+             * encrypted wallet. */
+            WalletModel::UnlockContext ctx(walletModel->requestUnlock());
+            if (!ctx.isValid())
+                return false;
+
             /* If passing an empty string delete the current scrape address
              * if one exists. */
             if (value.toString().toStdString().empty()) {

--- a/src/scrapesdb.cpp
+++ b/src/scrapesdb.cpp
@@ -5,40 +5,41 @@
 #include "bitcoinrpc.h"
 #include "scrapesdb.h"
 
-#define printf OutputDebugStringF
-
 using namespace json_spirit;
 using namespace std;
 
+extern Object JSONRPCError(int code, const string& message);
 extern CScrapesDB* scrapesDB;
 
 Value setscrapeaddress(const Array& params, bool fHelp)
 {
-    if (fHelp || params.size() != 2)
-        throw runtime_error(
-            "setscrapeaddress <staking address> <address to stake to>\n"
-            "Set an auto scrape address to send stake rewards to from a given address."
-        );
+    if (fHelp || params.size() != 2) {
+        string ret = "setscrapeaddress <staking address> <address to stake to>\nSet an auto scrape address to send stake rewards to from a given address.";
+        if (pwalletMain->IsCrypted())
+            ret += "requires wallet passphrase to be set with walletpassphrase first";
+
+        throw runtime_error(ret);
+    }
+
+    if (pwalletMain->IsLocked())
+        throw JSONRPCError(-13, "Error: Please enter the wallet passphrase with walletpassphrase first.");
 
     string strAddress = params[0].get_str();
     CBitcoinAddress address(strAddress);
     string strScrapeAddress = params[1].get_str();
     CBitcoinAddress scrapeAddress(strScrapeAddress);
 
+    if (!address.IsValid())
+        throw JSONRPCError(-5, "Invalid Paycoin address.");
+
     if (address.Get() == scrapeAddress.Get())
-        throw runtime_error(
-            "Cannot set scrape address to the same as staking address."
-        );
+        throw JSONRPCError(-1, "Cannot set scrape address to the same as staking address.");
 
     if (!IsMine(*pwalletMain, address.Get()))
-        throw runtime_error(
-            "Staking address must be in wallet."
-        );
+        throw JSONRPCError(-1, "Staking address must be in wallet.");
 
     if (!scrapeAddress.IsValid())
-        throw runtime_error(
-            "Invalid scrape address."
-        );
+        throw JSONRPCError(-5, "Invalid scrape address.");
 
     string oldScrapeAddress;
     bool warn = false;
@@ -59,9 +60,7 @@ Value setscrapeaddress(const Array& params, bool fHelp)
     }
 
     // This should never happen.
-    throw runtime_error(
-        "setscrapeaddress: unknown error"
-    );
+    throw JSONRPCError(-1, "setscrapeaddress: unknown error");
 }
 
 Value getscrapeaddress(const Array& params, bool fHelp)
@@ -75,16 +74,17 @@ Value getscrapeaddress(const Array& params, bool fHelp)
     string strAddress = params[0].get_str();
     CBitcoinAddress address(strAddress);
 
+    if (!address.IsValid())
+        throw JSONRPCError(-5, "Invalid Paycoin address.");
+
     if (!IsMine(*pwalletMain, address.Get()))
-        throw runtime_error(
-            "Staking address must be in wallet."
-        );
+        throw JSONRPCError(-1, "Staking address must be in wallet.");
 
     string strScrapeAddress;
     if (!scrapesDB->ReadScrapeAddress(strAddress, strScrapeAddress)) {
         string ret = "No scrape address set for address ";
         ret += strAddress;
-        throw runtime_error(ret);
+        throw JSONRPCError(-1, ret);
     }
 
     Object obj;
@@ -108,24 +108,30 @@ Value listscrapeaddresses(const Array& params, bool fHelp)
 
 Value deletescrapeaddress(const Array& params, bool fHelp)
 {
-    if (fHelp || params.size() != 1)
-        throw runtime_error(
-            "deletescrapeaddress <staking address>\n"
-            "Delete the auto scrape address for a given address."
-        );
+    if (fHelp || params.size() != 1) {
+        string ret = "deletescrapeaddress <staking address>\nDelete the auto scrape address for a given address.";
+        if (pwalletMain->IsCrypted())
+            ret += "requires wallet passphrase to be set with walletpassphrase first";
+
+        throw runtime_error(ret);
+    }
+
+    if (pwalletMain->IsLocked())
+        throw JSONRPCError(-13, "Error: Please enter the wallet passphrase with walletpassphrase first.");
 
     string strAddress = params[0].get_str();
     CBitcoinAddress address(strAddress);
 
+    if (!address.IsValid())
+        throw JSONRPCError(-5, "Invalid Paycoin address.");
+
     if (!IsMine(*pwalletMain, address.Get()))
-        throw runtime_error(
-            "Staking address must be in wallet."
-        );
+        throw JSONRPCError(-1, "Staking address must be in wallet.");
 
     if (!scrapesDB->HasScrapeAddress(strAddress)) {
         string ret = "No scrape address set for address ";
         ret += strAddress;
-        throw runtime_error(ret);
+        throw JSONRPCError(-1, ret);
     }
 
     return scrapesDB->EraseScrapeAddress(strAddress);

--- a/src/scrapesdb.cpp
+++ b/src/scrapesdb.cpp
@@ -8,7 +8,6 @@
 using namespace json_spirit;
 using namespace std;
 
-extern Object JSONRPCError(int code, const string& message);
 extern CScrapesDB* scrapesDB;
 
 Value setscrapeaddress(const Array& params, bool fHelp)

--- a/src/test/test_paycoin.cpp
+++ b/src/test/test_paycoin.cpp
@@ -21,6 +21,7 @@ struct TestingSetup {
         pwalletMain = new CWallet("wallet.dat");
         pwalletMain->LoadWallet(fFirstRun);
         RegisterWallet(pwalletMain);
+        scrapesDB = new CScrapesDB("cw");
     }
     ~TestingSetup()
     {


### PR DESCRIPTION
Check IsValid on all address instances instead of jumping to IsMine;
	provides clearer error information

Return error codes for scrape addresses;
	used -1 for most, is for misc error

Check if a wallet is encrypted and if it's locked when making changes
to the scrapes database.

Add full tests for rpc scrape functionality.