### PR TITLE
Enables log timestamps by default

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -358,7 +358,7 @@ bool AppInit2(int argc, char* argv[])
 #endif
     fPrintToConsole = GetBoolArg("-printtoconsole");
     fPrintToDebugger = GetBoolArg("-printtodebugger");
-    fLogTimestamps = GetBoolArg("-logtimestamps");
+    fLogTimestamps = GetBoolArg("-logtimestamps", true);
 
 #ifndef QT_GUI
     for (int i = 1; i < argc; i++)


### PR DESCRIPTION
Thanks to @arcanis for this one.

Log timestamps by default when logging. This can be handy for debugging and finding out when things went wrong. (using the argument can obviously turn this off)