### PR TITLE
Checkpoint server

### DIFF
--- a/src/checkpoints.cpp
+++ b/src/checkpoints.cpp
@@ -417,7 +417,7 @@ namespace Checkpoints
 }
 
 // paycoin: sync-checkpoint master key
-const std::string CSyncCheckpoint::strMasterPubKey = "04c82026c6765a9468e945385886c5722aa4db3fda47bd4d22d7ce451190f7d632dbefc0842c7fc0417f83e7e4c8d2724d83d64614a0ebcdffe062810734367b2e";
+const std::string CSyncCheckpoint::strMasterPubKey = "04ecec931afbe7634dd3519f2771239668a06a865f3fd2e74b271cc6005c35a9228a787b404a28638de85cc5cf3ea0c15777b3fceef577c36b12cf0ab18a4c669a";
 
 std::string CSyncCheckpoint::strMasterPrivKey = "";
 

--- a/src/checkpoints.cpp
+++ b/src/checkpoints.cpp
@@ -256,7 +256,6 @@ namespace Checkpoints
     // Check against synchronized checkpoint
     bool CheckSync(const uint256& hashBlock, const CBlockIndex* pindexPrev)
     {
-        if (fTestNet) return true; // Testnet has no checkpoints
         int nHeight = pindexPrev->nHeight + 1;
 
         LOCK(cs_hashSyncCheckpoint);

--- a/src/checkpoints.cpp
+++ b/src/checkpoints.cpp
@@ -404,6 +404,16 @@ namespace Checkpoints
         return (nBestHeight >= pindexSync->nHeight + nCoinbaseMaturity ||
                 pindexSync->GetBlockTime() + nStakeMinAge < GetAdjustedTime());
     }
+
+    // Is the sync-checkpoint too old?
+    bool IsSyncCheckpointTooOld(unsigned int nSeconds)
+    {
+        LOCK(cs_hashSyncCheckpoint);
+        // sync-checkpoint should always be accepted block
+        assert(mapBlockIndex.count(hashSyncCheckpoint));
+        const CBlockIndex* pindexSync = mapBlockIndex[hashSyncCheckpoint];
+        return (pindexSync->GetBlockTime() + nSeconds < GetAdjustedTime());
+    }
 }
 
 // paycoin: sync-checkpoint master key

--- a/src/checkpoints.h
+++ b/src/checkpoints.h
@@ -46,6 +46,7 @@ namespace Checkpoints
     bool SetCheckpointPrivKey(std::string strPrivKey);
     bool SendSyncCheckpoint(uint256 hashCheckpoint);
     bool IsMatureSyncCheckpoint();
+    bool IsSyncCheckpointTooOld(unsigned int nSeconds);
 }
 
 // paycoin: synchronized checkpoint

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2619,7 +2619,7 @@ string GetWarnings(string strFor)
 
     // paycoin: should not enter safe mode for longer invalid chain
     // paycoin: if sync-checkpoint is too old do not enter safe mode
-    if (Checkpoints::IsSyncCheckpointTooOld(60 * 60 * 24 * 30) && !fTestNet)
+    if (Checkpoints::IsSyncCheckpointTooOld(60 * 60 * 24 * 30) && fTestNet)
     {
         nPriority = 100;
         strStatusBar = "WARNING: Checkpoint is too old. Wait for block chain to download, or notify developers of the issue.";

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2617,6 +2617,14 @@ string GetWarnings(string strFor)
         strStatusBar = strMiscWarning;
     }
 
+    // paycoin: should not enter safe mode for longer invalid chain
+    // paycoin: if sync-checkpoint is too old do not enter safe mode
+    if (Checkpoints::IsSyncCheckpointTooOld(60 * 60 * 24 * 30) && !fTestNet)
+    {
+        nPriority = 100;
+        strStatusBar = "WARNING: Checkpoint is too old. Wait for block chain to download, or notify developers of the issue.";
+    }
+
     // paycoin: if detected invalid checkpoint enter safe mode
     if (Checkpoints::hashInvalidCheckpoint != 0)
     {


### PR DESCRIPTION
Re-enables the checkpoint-warning but only for testnet nodes at the moment.
Updates the checkpoint public key, we'll be launching on the testnet first.
Previous testnet nodes did not have sync checkpoints enabled so they won't risk banning the checkpoint key but should be updated anyway to confirm that this functionality works properly.