### PR TITLE
Minor update to protocol (not minimum protocol, no major effect)

### DIFF
--- a/src/version.h
+++ b/src/version.h
@@ -61,7 +61,7 @@ extern const std::string CLIENT_DATE;
 // network protocol versioning
 //
 
-static const int PROTOCOL_VERSION = 70005;
+static const int PROTOCOL_VERSION = 70006;
 
 /* As of Paycoin protocol 70002 the MIN_PROTO_VERSION is initialized
  * and determined in init to allow for a pseudo dynamic change of minimum


### PR DESCRIPTION
This is just so that the alert I sent out on the testnet gets
cancelled, otherwise they're stuck with an annoying message until
the next update.