### PR TITLE
CTxMemPool: consolidate two frequently-printed debug.log lines into one

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -626,7 +626,7 @@ bool CTxMemPool::accept(CTxDB& txdb, CTransaction &tx, bool fCheckInputs,
                 return error("CTxMemPool::accept() : FetchInputs found invalid tx %s", hash.ToString().substr(0,10).c_str());
             if (pfMissingInputs)
                 *pfMissingInputs = true;
-            return error("CTxMemPool::accept() : FetchInputs failed %s", hash.ToString().substr(0,10).c_str());
+            return false;
         }
 
         // Check for non-standard pay-to-script-hash in inputs

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -697,7 +697,9 @@ bool CTxMemPool::accept(CTxDB& txdb, CTransaction &tx, bool fCheckInputs,
     if (ptxOld)
         EraseFromWallets(ptxOld->GetHash());
 
-    printf("CTxMemPool::accept() : accepted %s\n", hash.ToString().substr(0,10).c_str());
+    printf("CTxMemPool::accept() : accepted %s (poolsz %u)\n",
+           hash.ToString().substr(0,10).c_str(),
+           mapTx.size());
     return true;
 }
 
@@ -708,7 +710,6 @@ bool CTransaction::AcceptToMemoryPool(CTxDB& txdb, bool fCheckInputs, bool* pfMi
 
 bool CTxMemPool::addUnchecked(const uint256& hash, CTransaction &tx)
 {
-    printf("addUnchecked(): size %lu\n",  mapTx.size());
     // Add to memory pool without checking anything.  Don't call this directly,
     // call CTxMemPool::accept to properly check the transaction first.
     {


### PR DESCRIPTION
Previously, a single TX would trigger two log lines in quick succession,

        addUnchecked(): size 1
        CTxMemPool::accept() : accepted d17048a315

After this change, only one log line is used:

        CTxMemPool::accept() : accepted d17048a315 (poolsz 1)

A second commit, which further quietens the logging, without losing information.