### PR TITLE
guiutil.cpp/.h: fix a -Wreorder compiler warning...

### DIFF
--- a/src/qt/guiutil.cpp
+++ b/src/qt/guiutil.cpp
@@ -246,8 +246,8 @@ void openDebugLogfile()
 #endif
 }
 
-ToolTipToRichTextFilter::ToolTipToRichTextFilter(int size_threshold, QObject *parent):
-    size_threshold(size_threshold), QObject(parent)
+ToolTipToRichTextFilter::ToolTipToRichTextFilter(int size_threshold, QObject *parent) :
+    QObject(parent), size_threshold(size_threshold)
 {
 
 }

--- a/src/qt/guiutil.h
+++ b/src/qt/guiutil.h
@@ -77,11 +77,11 @@ namespace GUIUtil
       representation if needed. This assures that Qt can word-wrap long tooltip messages.
       Tooltips longer than the provided size threshold (in characters) are wrapped.
      */
-    class ToolTipToRichTextFilter: public QObject
+    class ToolTipToRichTextFilter : public QObject
     {
         Q_OBJECT
     public:
-        ToolTipToRichTextFilter(int size_threshold, QObject *parent);
+        explicit ToolTipToRichTextFilter(int size_threshold, QObject *parent = 0);
 
     protected:
         bool eventFilter(QObject *obj, QEvent *evt);


### PR DESCRIPTION
I've wanted to squash these warnings for a while now!

- Fix for:
```
src/qt/guiutil.h: In constructor ‘GUIUtil::ToolTipToRichTextFilter::ToolTipToRichTextFilter(int, QObject*)’:
src/qt/guiutil.h:90: warning: ‘GUIUtil::ToolTipToRichTextFilter::size_threshold’ will be initialized after [-Wreorder]
src/qt/guiutil.cpp:250: warning: base ‘QObject’ [-Wreorder]
src/qt/guiutil.cpp:249: warning: when initialized here [-Wreorder]
```

- Make constructor for ToolTipToRichTextFilter explicit

