### PR TITLE
When a transaction is clicked on overview page, focus it on history page

### DIFF
--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -178,6 +178,7 @@ BitcoinGUI::BitcoinGUI(QWidget *parent):
 
     // Clicking on a transaction on the overview page simply sends you to transaction history page
     connect(overviewPage, SIGNAL(transactionClicked(QModelIndex)), this, SLOT(gotoHistoryPage()));
+    connect(overviewPage, SIGNAL(transactionClicked(QModelIndex)), transactionView, SLOT(focusTransaction(QModelIndex)));
 
     // Double-clicking on a transaction on the transaction history page shows details
     connect(transactionView, SIGNAL(doubleClicked(QModelIndex)), transactionView, SLOT(showDetails()));

--- a/src/qt/overviewpage.cpp
+++ b/src/qt/overviewpage.cpp
@@ -95,7 +95,7 @@ OverviewPage::OverviewPage(QWidget *parent) :
     currentBalance(-1),
     currentStake(0),
     currentUnconfirmedBalance(-1),
-    txdelegate(new TxViewDelegate())
+    txdelegate(new TxViewDelegate()), filter(0)
 {
     ui->setupUi(this);
 
@@ -105,7 +105,7 @@ OverviewPage::OverviewPage(QWidget *parent) :
     ui->listTransactions->setMinimumHeight(NUM_ITEMS * (DECORATION_SIZE + 2));
     ui->listTransactions->setAttribute(Qt::WA_MacShowFocusRect, false);
 
-    connect(ui->listTransactions, SIGNAL(clicked(QModelIndex)), this, SIGNAL(transactionClicked(QModelIndex)));
+    connect(ui->listTransactions, SIGNAL(clicked(QModelIndex)), this, SLOT(handleTransactionClicked(QModelIndex)));
 
     // init "out of sync" warning labels
     ui->labelWalletStatus->setText("(" + tr("out of sync") + ")");
@@ -113,6 +113,12 @@ OverviewPage::OverviewPage(QWidget *parent) :
 
     // start with displaying the "out of sync" warnings
     showOutOfSyncWarning(true);
+}
+
+void OverviewPage::handleTransactionClicked(const QModelIndex &index)
+{
+    if(filter)
+        emit transactionClicked(filter->mapToSource(index));
 }
 
 OverviewPage::~OverviewPage()
@@ -142,7 +148,7 @@ void OverviewPage::setModel(WalletModel *model)
     if(model)
     {
         // Set up transaction list
-        TransactionFilterProxy *filter = new TransactionFilterProxy();
+        filter = new TransactionFilterProxy();
         filter->setSourceModel(model->getTransactionTableModel());
         filter->setLimit(NUM_ITEMS);
         filter->setDynamicSortFilter(true);

--- a/src/qt/overviewpage.h
+++ b/src/qt/overviewpage.h
@@ -12,6 +12,7 @@ namespace Ui {
 }
 class WalletModel;
 class TxViewDelegate;
+class TransactionFilterProxy;
 
 /** Overview ("home") page widget */
 class OverviewPage : public QWidget
@@ -40,9 +41,11 @@ private:
     qint64 currentUnconfirmedBalance;
 
     TxViewDelegate *txdelegate;
+    TransactionFilterProxy *filter;
 
 private slots:
     void displayUnitChanged();
+    void handleTransactionClicked(const QModelIndex &index);
 };
 
 #endif // OVERVIEWPAGE_H

--- a/src/qt/transactionview.cpp
+++ b/src/qt/transactionview.cpp
@@ -467,3 +467,13 @@ void TransactionView::dateRangeChanged()
             QDateTime(dateFrom->date()),
             QDateTime(dateTo->date()).addDays(1));
 }
+
+void TransactionView::focusTransaction(const QModelIndex &idx)
+{
+    if(!transactionProxyModel)
+        return;
+    QModelIndex targetIdx = transactionProxyModel->mapFromSource(idx);
+    transactionView->scrollTo(targetIdx);
+    transactionView->setCurrentIndex(targetIdx);
+    transactionView->setFocus();
+}

--- a/src/qt/transactionview.h
+++ b/src/qt/transactionview.h
@@ -78,6 +78,7 @@ public slots:
     void changedPrefix(const QString &prefix);
     void changedAmount(const QString &amount);
     void exportClicked();
+    void focusTransaction(const QModelIndex&);
 
 };
 


### PR DESCRIPTION
Currently, when a transaction item is clicked on the overview page it jumps to the history page. This pull request extends this behavior to focus and select the clicked transaction.