### PR TITLE
Introduce -debugnet option, thereby quieting some redundant debug messages

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -268,7 +268,8 @@ std::string HelpMessage()
         "  -daemon               "   + _("Run in the background as a daemon and accept commands") + "\n" +
 #endif
         "  -testnet              "   + _("Use the test network") + "\n" +
-        "  -debug                "   + _("Output extra debugging information") + "\n" +
+        "  -debug                "   + _("Output extra debugging information. Implies all other -debug* options") + "\n" +
+        "  -debugnet             "   + _("Output extra network debugging information") + "\n" +
         "  -logtimestamps        "   + _("Prepend debug output with timestamp") + "\n" +
         "  -printtoconsole       "   + _("Send trace/debug info to console instead of debug.log file") + "\n" +
 #ifdef WIN32
@@ -341,13 +342,6 @@ bool AppInit2()
 #endif
 
     fDebug = GetBoolArg("-debug");
-
-    // -debug implies fDebug*
-    if (fDebug)
-        fDebugNet = true;
-    else
-        fDebugNet = GetBoolArg("-debugnet");
-
     bitdb.SetDetach(GetBoolArg("-detachdb", false));
 
 #if !defined(WIN32) && !defined(QT_GUI)

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -341,6 +341,13 @@ bool AppInit2()
 #endif
 
     fDebug = GetBoolArg("-debug");
+
+    // -debug implies fDebug*
+    if (fDebug)
+        fDebugNet = true;
+    else
+        fDebugNet = GetBoolArg("-debugnet");
+
     bitdb.SetDetach(GetBoolArg("-detachdb", false));
 
 #if !defined(WIN32) && !defined(QT_GUI)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3616,7 +3616,8 @@ bool SendMessages(CNode* pto, bool fSendTrickle)
             const CInv& inv = (*pto->mapAskFor.begin()).second;
             if (!AlreadyHave(txdb, inv))
             {
-                printf("sending getdata: %s\n", inv.ToString().c_str());
+                if (fDebugNet)
+                    printf("sending getdata: %s\n", inv.ToString().c_str());
                 vGetData.push_back(inv);
                 if (vGetData.size() >= 1000)
                 {

--- a/src/net.h
+++ b/src/net.h
@@ -295,7 +295,8 @@ public:
         // We're using mapAskFor as a priority queue,
         // the key is the earliest time the request can be sent
         int64& nRequestTime = mapAlreadyAskedFor[inv];
-        printf("askfor %s   %"PRI64d"\n", inv.ToString().c_str(), nRequestTime);
+        if (fDebugNet)
+            printf("askfor %s   %"PRI64d"\n", inv.ToString().c_str(), nRequestTime);
 
         // Make sure not to reuse time indexes to keep things in the same order
         int64 nNow = (GetTime() - 1) * 1000000;

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -66,6 +66,7 @@ using namespace boost;
 map<string, string> mapArgs;
 map<string, vector<string> > mapMultiArgs;
 bool fDebug = false;
+bool fDebugNet = false;
 bool fPrintToConsole = false;
 bool fPrintToDebugger = false;
 bool fRequestShutdown = false;

--- a/src/util.h
+++ b/src/util.h
@@ -123,6 +123,7 @@ void LogStackTrace();
 extern std::map<std::string, std::string> mapArgs;
 extern std::map<std::string, std::vector<std::string> > mapMultiArgs;
 extern bool fDebug;
+extern bool fDebugNet;
 extern bool fPrintToConsole;
 extern bool fPrintToDebugger;
 extern bool fRequestShutdown;


### PR DESCRIPTION
Prior to this change, each TX typically generated 3+ debug messages,

    askfor tx 8644cc97480ba1537214   0
    sending getdata: tx 8644cc97480ba1537214
    askfor tx 8644cc97480ba1537214   1339640761000000
    askfor tx 8644cc97480ba1537214   1339640881000000
    CTxMemPool::accept() : accepted 8644cc9748 (poolsz 6857)

After this change, there is only one message for each valid TX received

    CTxMemPool::accept() : accepted 22a73c5d8c (poolsz 42)

and two messages for each orphan tx received

    ERROR: FetchInputs() : 673dc195aa mempool Tx prev not found 1e439346fc
    stored orphan tx 673dc195aa (mapsz 19)

The -debugnet option, or its superset -debug, will restore the full debug
output.