### PR TITLE
Unless debugging, show a more useful format for the askfors

### DIFF
--- a/src/net.h
+++ b/src/net.h
@@ -296,7 +296,7 @@ public:
         // the key is the earliest time the request can be sent
         int64& nRequestTime = mapAlreadyAskedFor[inv];
         if (fDebugNet)
-            printf("askfor %s   %"PRI64d"\n", inv.ToString().c_str(), nRequestTime);
+            printf("askfor %s   %"PRI64d" (%s)\n", inv.ToString().c_str(), nRequestTime, DateTimeStrFormat("%H:%M:%S", nRequestTime/1000000).c_str());
 
         // Make sure not to reuse time indexes to keep things in the same order
         int64 nNow = (GetTime() - 1) * 1000000;


### PR DESCRIPTION
Will show a human readable time that the getdata will be triggered. Easier to follow. 