### PR TITLE
JSON-RPC: remove 'getblocknumber' deprecated RPC

### DIFF
--- a/src/bitcoinrpc.cpp
+++ b/src/bitcoinrpc.cpp
@@ -197,10 +197,7 @@ string CRPCTable::help(string strCommand) const
         const CRPCCommand *pcmd = mi->second;
         string strMethod = mi->first;
         // We already filter duplicates, but these deprecated screw up the sort order
-        if (strMethod == "getamountreceived" ||
-            strMethod == "getallreceived" ||
-            strMethod == "getblocknumber" || // deprecated
-            (strMethod.find("label") != string::npos))
+        if (strMethod.find("label") != string::npos)
             continue;
         if (strCommand != "" && strMethod != strCommand)
             continue;
@@ -260,18 +257,6 @@ Value getblockcount(const Array& params, bool fHelp)
         throw runtime_error(
             "getblockcount\n"
             "Returns the number of blocks in the longest block chain.");
-
-    return nBestHeight;
-}
-
-
-// deprecated
-Value getblocknumber(const Array& params, bool fHelp)
-{
-    if (fHelp || params.size() != 0)
-        throw runtime_error(
-            "getblocknumber\n"
-            "Deprecated.  Use getblockcount.");
 
     return nBestHeight;
 }
@@ -2861,7 +2846,6 @@ static const CRPCCommand vRPCCommands[] =
     { "help",                   &help,                   true },
     { "stop",                   &stop,                   true },
     { "getblockcount",          &getblockcount,          true },
-    { "getblocknumber",         &getblocknumber,         true },
     { "listaddressbook",        &listaddressbook,        false },
     { "getconnectioncount",     &getconnectioncount,     true },
     { "getpeerinfo",            &getpeerinfo,            true },


### PR DESCRIPTION
RPC 'getblockcount' should be used instead.