### PR TITLE
add client startup time as an entry to debug.log

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -390,6 +390,7 @@ bool AppInit2()
     printf("\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n");
     printf("Paycoin version %s (%s)\n", FormatFullVersion().c_str(), CLIENT_DATE.c_str());
     printf("Using OpenSSL version %s\n", SSLeay_version(SSLEAY_VERSION));
+    printf("Startup time: %s\n", DateTimeStrFormat("%x %H:%M:%S", GetTime()).c_str());
     printf("Default data directory %s\n", GetDefaultDataDir().string().c_str());
     printf("Used data directory %s\n", GetDataDir().string().c_str());
 

--- a/src/qt/clientmodel.cpp
+++ b/src/qt/clientmodel.cpp
@@ -100,7 +100,7 @@ QString ClientModel::clientName() const
     return QString::fromStdString(CLIENT_NAME);
 }
 
-QDateTime ClientModel::formatClientStartupTime() const
+QString ClientModel::formatClientStartupTime() const
 {
-    return QDateTime::fromTime_t(nClientStartupTime);
+    return QDateTime::fromTime_t(nClientStartupTime).toString();
 }

--- a/src/qt/clientmodel.h
+++ b/src/qt/clientmodel.h
@@ -39,7 +39,7 @@ public:
     QString formatFullVersion() const;
     QString formatBuildDate() const;
     QString clientName() const;
-    QDateTime formatClientStartupTime() const;
+    QString formatClientStartupTime() const;
 
 private:
     OptionsModel *optionsModel;

--- a/src/qt/rpcconsole.cpp
+++ b/src/qt/rpcconsole.cpp
@@ -269,7 +269,7 @@ void RPCConsole::setClientModel(ClientModel *model)
         ui->clientVersion->setText(model->formatFullVersion());
         ui->clientName->setText(model->clientName());
         ui->buildDate->setText(model->formatBuildDate());
-        ui->startupTime->setText(model->formatClientStartupTime().toString());
+        ui->startupTime->setText(model->formatClientStartupTime());
 
         setNumConnections(model->getNumConnections());
         ui->isTestNet->setChecked(model->isTestNet());


### PR DESCRIPTION
- make ClientModel::formatClientStartupTime() return a QString

Note: Logged time in debug.log differs by a few seconds from the one displayed in the Debug window because of different initialisation times.