### PR TITLE
GUI: merge toggleHidden() code into showNormalIfMinimized()

### DIFF
--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -475,28 +475,6 @@ void BitcoinGUI::trayIconActivated(QSystemTrayIcon::ActivationReason reason)
 }
 #endif
 
-void BitcoinGUI::toggleHidden()
-{
-    // activateWindow() (sometimes) helps with keyboard focus on Windows
-    if (isHidden())
-    {
-        show();
-        activateWindow();
-    }
-    else if (isMinimized())
-    {
-        showNormal();
-        activateWindow();
-    }
-    else if (GUIUtil::isObscured(this))
-    {
-        raise();
-        activateWindow();
-    }
-    else
-        hide();
-}
-
 void BitcoinGUI::optionsClicked()
 {
     if(!clientModel || !clientModel->getOptionsModel())
@@ -833,9 +811,6 @@ void BitcoinGUI::handleURI(QString strURI)
     gotoSendCoinsPage();
     sendCoinsPage->handleURI(strURI);
 
-    if(!isActiveWindow())
-        activateWindow();
-
     showNormalIfMinimized();
 }
 
@@ -949,10 +924,29 @@ void BitcoinGUI::unlockWallet()
     }
 }
 
-void BitcoinGUI::showNormalIfMinimized()
+void BitcoinGUI::showNormalIfMinimized(bool fToggleHidden)
 {
-    if(!isVisible()) // Show, if hidden
+    // activateWindow() (sometimes) helps with keyboard focus on Windows
+    if (isHidden())
+    {
         show();
-    if(isMinimized()) // Unminimize, if minimized
+        activateWindow();
+    }
+    else if (isMinimized())
+    {
         showNormal();
+        activateWindow();
+    }
+    else if (GUIUtil::isObscured(this))
+    {
+        raise();
+        activateWindow();
+    }
+    else if(fToggleHidden)
+        hide();
+}
+
+void BitcoinGUI::toggleHidden()
+{
+    showNormalIfMinimized(true);
 }

--- a/src/qt/bitcoingui.h
+++ b/src/qt/bitcoingui.h
@@ -179,9 +179,9 @@ private slots:
     /** Ask for passphrase to unlock wallet temporarily */
     void unlockWallet();
 
-    /** Show window if hidden, unminimize when minimized */
-    void showNormalIfMinimized();
-    /** Hide window if visible, show if hidden */
+    /** Show window if hidden, unminimize when minimized, rise when obscured or show if hidden and fToggleHidden is true */
+    void showNormalIfMinimized(bool fToggleHidden = false);
+    /** simply calls showNormalIfMinimized(true) for use in SLOT() macro */
     void toggleHidden();
 };
 


### PR DESCRIPTION
- to extend the functionality, but keep a simpler toggleHidden() for use in SLOT() macro

As toggleHidden() has some functionality in, that is good for showNormalIfMinimized() I moved the code to it.

I was not able to completely remove toggleHidden(), as SLOT(showNormalIfMinimized(true)) is not allowed. "Binding" a parameter, as it is called, to a SIGNAL or SLOT is not possible with Qt, so we'll need to keep toggleHidden around.

Also removed this from handleURI:
```
if(!isActiveWindow())
    activateWindow();
```