### PR TITLE
Change strings to Paycoin (uppercase) and other miscellaneous fixes

### DIFF
--- a/src/base58.h
+++ b/src/base58.h
@@ -255,7 +255,7 @@ public:
     bool operator> (const CBase58Data& b58) const { return CompareTo(b58) >  0; }
 };
 
-/** base58-encoded bitcoin addresses.
+/** base58-encoded Paycoin addresses.
  * Public-key-hash-addresses have version 55 (or 111 testnet).
  * The data vector contains RIPEMD160(SHA256(pubkey)), where pubkey is the serialized public key.
  * Script-hash-addresses have version 117 (or 196 testnet).

--- a/src/bitcoinrpc.cpp
+++ b/src/bitcoinrpc.cpp
@@ -2568,7 +2568,7 @@ CScript _createmultisig(const Array& params)
     {
         const std::string& ks = keys[i].get_str();
 
-        // Case 1: Bitcoin address and we have full public key:
+        // Case 1: Paycoin address and we have full public key:
         CBitcoinAddress address(ks);
         if (pwalletMain && address.IsValid())
         {
@@ -2607,7 +2607,7 @@ Value addmultisigaddress(const Array& params, bool fHelp)
     {
         string msg = "addmultisigaddress <nrequired> <'[\"key\",\"key\"]'> [account]\n"
             "Add a nrequired-to-sign multisignature address to the wallet\n"
-            "each key is a paycoin address or hex-encoded public key\n"
+            "each key is a Paycoin address or hex-encoded public key\n"
             "If [account] is specified, assign address to [account].";
         throw runtime_error(msg);
     }

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -423,7 +423,7 @@ bool AppInit2()
 
     // ********************************************************* Step 4: application initialization: dir lock, daemonize, pidfile, debug log
 
-    // Make sure only a single paycoin process is using the data directory.
+    // Make sure only a single Paycoin process is using the data directory.
     boost::filesystem::path pathLockFile = GetDataDir() / ".lock";
     FILE* file = fopen(pathLockFile.string().c_str(), "a"); // empty lock file; created if it doesn't exist.
     if (file) fclose(file);

--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -461,7 +461,7 @@ void BitcoinGUI::createTrayIcon()
     trayIconMenu->addAction(quitAction);
 #endif
 
-    notificator = new Notificator(tr("p-qt"), trayIcon);
+    notificator = new Notificator(qApp->applicationName(), trayIcon);
 }
 
 #ifndef Q_OS_MAC
@@ -469,7 +469,7 @@ void BitcoinGUI::trayIconActivated(QSystemTrayIcon::ActivationReason reason)
 {
     if(reason == QSystemTrayIcon::Trigger)
     {
-        // Click on system tray icon triggers "show/hide bitcoin"
+        // Click on system tray icon triggers "show/hide Paycoin"
         toggleHideAction->trigger();
     }
 }

--- a/src/qt/guiutil.h
+++ b/src/qt/guiutil.h
@@ -22,7 +22,7 @@ namespace GUIUtil
     QString dateTimeStr(const QDateTime &datetime);
     QString dateTimeStr(qint64 nTime);
 
-    // Render bitcoin addresses in monospace font
+    // Render Paycoin addresses in monospace font
     QFont bitcoinAddressFont();
 
     // Set up widgets for address and amounts

--- a/src/qt/optionsmodel.cpp
+++ b/src/qt/optionsmodel.cpp
@@ -24,7 +24,7 @@ void OptionsModel::Init()
     fCoinControlFeatures = settings.value("fCoinControlFeatures", false).toBool();
     language = settings.value("language", "").toString();
 
-    // These are shared with core bitcoin; we want
+    // These are shared with core Paycoin; we want
     // command-line options to override the GUI settings:
     if (settings.contains("fUseUPnP"))
         SoftSetBoolArg("-upnp", settings.value("fUseUPnP").toBool());

--- a/src/qt/optionsmodel.h
+++ b/src/qt/optionsmodel.h
@@ -3,8 +3,8 @@
 
 #include <QAbstractListModel>
 
-/** Interface from QT to configuration data structure for bitcoin client.
-   To QT, the options are presented as a list with the different options
+/** Interface from Qt to configuration data structure for Paycoin client.
+   To Qt, the options are presented as a list with the different options
    laid out vertically.
    This can be changed to a tree once the settings become sufficiently
    complex.

--- a/src/qt/rpcconsole.h
+++ b/src/qt/rpcconsole.h
@@ -8,7 +8,7 @@ namespace Ui {
 }
 class ClientModel;
 
-/** Local bitcoin RPC console. */
+/** Local Paycoin RPC console. */
 class RPCConsole: public QDialog
 {
     Q_OBJECT

--- a/src/test/util_tests.cpp
+++ b/src/test/util_tests.cpp
@@ -105,7 +105,7 @@ BOOST_AUTO_TEST_CASE(util_DateTimeStrFormat)
 {
     BOOST_CHECK_EQUAL(DateTimeStrFormat("%x %H:%M:%S", 0), "01/01/70 00:00:00");
     BOOST_CHECK_EQUAL(DateTimeStrFormat("%x %H:%M:%S", 0x7FFFFFFF), "01/19/38 03:14:07");
-    // Formats used within bitcoin
+    // Formats used within Paycoin
     BOOST_CHECK_EQUAL(DateTimeStrFormat("%x %H:%M:%S", 1317425777), "09/30/11 23:36:17");
     BOOST_CHECK_EQUAL(DateTimeStrFormat("%x %H:%M", 1317425777), "09/30/11 23:36");
 }

--- a/src/version.h
+++ b/src/version.h
@@ -14,7 +14,7 @@
 
 // These need to be macro's, as version.cpp's voodoo requires it
 
-// paycoin version - intended for display purpose only
+// Paycoin version - intended for display purpose only
 #define PEERUNITY_VERSION_MAJOR       0
 #define PEERUNITY_VERSION_MINOR       3
 #define PEERUNITY_VERSION_REVISION    3
@@ -26,7 +26,7 @@ static const int PEERUNITY_VERSION =
                          +     100 * PEERUNITY_VERSION_REVISION
                          +       1 * PEERUNITY_VERSION_BUILD;
 
-// paycoin version - reference for code tracking
+// Peercoin version - reference for code tracking
 #define PPCOIN_VERSION_MAJOR       0
 #define PPCOIN_VERSION_MINOR       4
 #define PPCOIN_VERSION_REVISION    0
@@ -38,7 +38,7 @@ static const int PPCOIN_VERSION =
                          +     100 * PPCOIN_VERSION_REVISION
                          +       1 * PPCOIN_VERSION_BUILD;
 
-// bitcoin version - reference for code tracking
+// Bitcoin version - reference for code tracking
 #define BITCOIN_VERSION_MAJOR       0
 #define BITCOIN_VERSION_MINOR       6
 #define BITCOIN_VERSION_REVISION    3

--- a/src/wallet.cpp
+++ b/src/wallet.cpp
@@ -1703,7 +1703,7 @@ string CWallet::SendMoneyToDestination(const CTxDestination& address, int64 nVal
     if (nValue + nTransactionFee > GetBalance())
         return _("Insufficient funds");
 
-    // Parse bitcoin address
+    // Parse Paycoin address
     CScript scriptPubKey;
     scriptPubKey.SetDestination(address);
 


### PR DESCRIPTION
- Update strings to use "Qt" (and not qt or QT)
- Revert a reference to Peercoin that was replaced with Paycoin
- Update initialisation of notificator to use qApp->applicationName() instead of a static string