### PR TITLE
Correct translatable string from Bitcoin to Paycoin

### DIFF
--- a/src/qt/optionsdialog.cpp
+++ b/src/qt/optionsdialog.cpp
@@ -355,7 +355,7 @@ NetworkOptionsPage::NetworkOptionsPage(QWidget *parent):
     layout->addWidget(map_port_upnp);
 
     connect_socks4 = new QCheckBox(tr("&Connect through SOCKS4 proxy:"));
-    connect_socks4->setToolTip(tr("Connect to the Bitcon network through a SOCKS4 proxy (e.g. when connecting through Tor)"));
+    connect_socks4->setToolTip(tr("Connect to the Paycoin network through a SOCKS4 proxy (e.g. when connecting through Tor)"));
     layout->addWidget(connect_socks4);
 
     QHBoxLayout *proxy_hbox = new QHBoxLayout();


### PR DESCRIPTION
This fixes an issue raised by a translator on Transifex.

Will push a translation master file update in a future pull closer to the next release.