### PR TITLE
Small fix to rpc_tests

### DIFF
--- a/src/test/rpc_tests.cpp
+++ b/src/test/rpc_tests.cpp
@@ -34,9 +34,9 @@ BOOST_FIXTURE_TEST_CASE(rpc_addmultisig, TestNetFixture)
     rpcfn_type addmultisig = tableRPC["addmultisigaddress"]->actor;
 
     // old, 65-byte-long:
-    const char* address1Hex = "0434e3e09f49ea168c5bbf53f877ff4206923858aab7c7e1df25bc263978107c95e35065a27ef6f1b27222db0ec97e0e895eaca603d3ee0d4c060ce3d8a00286c8";
+    const char address1Hex[] = "0434e3e09f49ea168c5bbf53f877ff4206923858aab7c7e1df25bc263978107c95e35065a27ef6f1b27222db0ec97e0e895eaca603d3ee0d4c060ce3d8a00286c8";
     // new, compressed:
-    const char* address2Hex = "0388c2037017c62240b6b72ac1a2a5f94da790596ebd06177c8572752922165cb4";
+    const char address2Hex[] = "0388c2037017c62240b6b72ac1a2a5f94da790596ebd06177c8572752922165cb4";
 
     Value v;
     CBitcoinAddress address;
@@ -62,7 +62,7 @@ BOOST_FIXTURE_TEST_CASE(rpc_addmultisig, TestNetFixture)
     string short1(address1Hex, address1Hex+sizeof(address1Hex)-2); // last byte missing
     BOOST_CHECK_THROW(addmultisig(createArgs(2, short1.c_str()), false), runtime_error);
 
-    string short2(address1Hex+2, address1Hex+sizeof(address1Hex)); // first byte missing
+    string short2(address1Hex+1, address1Hex+sizeof(address1Hex)); // first byte missing
     BOOST_CHECK_THROW(addmultisig(createArgs(2, short2.c_str()), false), runtime_error);
 }
 


### PR DESCRIPTION
sizeof(const char*) == 4 or 8 (on "sane" processor architectures) :-), sizeof(const char[]) is what you want.

As written the first substring was "04" and the second was "88c2" (on 32 bits architectures)

And I have changed the +2 in +1 so that the comment is right.