### PR TITLE
Use linker-arguments only when linking

### DIFF
--- a/src/makefile.unix
+++ b/src/makefile.unix
@@ -69,13 +69,14 @@ LIBS+= \
     # Make some important things such as the global offset table read only as soon as
     # the dynamic linker is finished building it. This will prevent overwriting of addresses
     # which would later be jumped to.
-    HARDENING+=-Wl,-z,relro -Wl,-z,now
+    LDHARDENING+=-Wl,-z,relro -Wl,-z,now
 
     # Build position independent code to take advantage of Address Space Layout Randomization
     # offered by some kernels.
     # see doc/build-unix.md for more information.
     ifdef PIE
-        HARDENING+=-fPIE -pie
+        HARDENING+=-fPIE
+        LDHARDENING+=-pie
     endif
 
     # -D_FORTIFY_SOURCE=2 does some checking for potentially exploitable code patterns in
@@ -88,6 +89,10 @@ DEBUGFLAGS=-g
 CXXFLAGS=-O2
 xCXXFLAGS=-pthread -Wall -Wextra -Wno-sign-compare -Wno-invalid-offsetof -Wno-unused-parameter -Wformat -Wformat-security \
     $(DEBUGFLAGS) $(DEFS) $(HARDENING) $(CXXFLAGS)
+
+# LDFLAGS can be specified on the make command line, so we use xLDFLAGS that only
+# adds some defaults in front. Unfortunately, LDFLAGS=... $(LDFLAGS) does not work.
+xLDFLAGS=$(LDHARDENING) $(LDFLAGS)
 
 OBJS= \
     obj/version.o \
@@ -147,7 +152,7 @@ obj/%.o: %.cpp
 	  rm -f $(@:%.o=%.d)
 
 paycoind: $(OBJS:obj/%=obj/%)
-	$(CXX) $(xCXXFLAGS) -rdynamic -o $@ $^ $(LDFLAGS) $(LIBS)
+	$(CXX) $(xCXXFLAGS) -rdynamic -o $@ $^ $(xLDFLAGS) $(LIBS)
 
 TESTOBJS := $(patsubst test/%.cpp,obj-test/%.o,$(wildcard test/*.cpp))
 
@@ -159,7 +164,7 @@ obj-test/%.o: test/%.cpp
 	  rm -f $(@:%.o=%.d)
 
 test_paycoin: $(TESTOBJS) $(filter-out obj/init.o,$(OBJS:obj/%=obj/%))
-	$(CXX) $(xCXXFLAGS) -o $@ $(LIBPATHS) $^ -Wl,-B$(LMODE) -lboost_unit_test_framework $(LDFLAGS) $(LIBS)
+	$(CXX) $(xCXXFLAGS) -o $@ $(LIBPATHS) $^ -Wl,-B$(LMODE) -lboost_unit_test_framework $(xLDFLAGS) $(LIBS)
 
 clean:
 	-rm -f paycoind test_paycoin


### PR DESCRIPTION
Passing linker-arguments when only compiling will cause warnings with Clang. This change fixes those.

Specifically this addresses warnings like these:
```
clang: warning: -Wl,-z,relro: 'linker' input unused when '-c' is present
clang: warning: -Wl,-z,now: 'linker' input unused when '-c' is present
clang: warning: argument unused during compilation: '-pie'
```


You can see the diff on my dev branch with clang turned on in Travis.
*With warnings:*
https://travis-ci.org/mitchellcash/paycoin/jobs/96497643
*Without warnings:*
https://travis-ci.org/mitchellcash/paycoin/jobs/96499171