### PR TITLE
Paycoin-Qt (Windows only): extend Resource File

### DIFF
--- a/src/qt/res/bitcoin-qt.rc
+++ b/src/qt/res/bitcoin-qt.rc
@@ -1,1 +1,27 @@
 IDI_ICON1 ICON DISCARDABLE "icons/paycoin.ico"
+
+#include <windows.h> // needed for VERSIONINFO
+
+VS_VERSION_INFO VERSIONINFO
+FILEOS         	VOS_NT_WINDOWS32
+FILETYPE       	VFT_APP
+BEGIN
+    BLOCK "StringFileInfo"
+    BEGIN
+        BLOCK "040904E4" // U.S. English - multilingual (hex)
+        BEGIN
+            VALUE "CompanyName",        "Paycoin"
+            VALUE "FileDescription",    "Paycoin-Qt (OSS GUI client for Paycoin)"
+            VALUE "InternalName",       "paycoin-qt"
+            VALUE "LegalCopyright",     "2014-2015 The Paycoin developers"
+            VALUE "LegalTrademarks1",   "Distributed under the MIT software license, see the accompanying file COPYING or http://www.opensource.org/licenses/mit-license.php."
+            VALUE "OriginalFilename",   "paycoin-qt.exe"
+            VALUE "ProductName",        "Paycoin-Qt"
+        END
+    END
+
+    BLOCK "VarFileInfo"
+    BEGIN
+        VALUE "Translation", 0x0, 1252 // language neutral - multilingual (decimal)
+    END
+END


### PR DESCRIPTION
- extend bitcoin-qt.rc to include meta information, which is displayed on Windows, when looking in the executable properties and selecting "Details"
- does currently NOT include version information, this is scheduled for later releases
- for RC-file documentation see: http://msdn.microsoft.com/en-us/library/windows/desktop/aa381058%28v=vs.85%29.aspx

![](https://dl.dropboxusercontent.com/u/37902134/GitHub/PaycoinFoundation%3Apaycoin/%23416_0.png)