### PR TITLE
Remove comma from setscrapeaddress description

### DIFF
--- a/src/scrapesdb.cpp
+++ b/src/scrapesdb.cpp
@@ -16,7 +16,7 @@ Value setscrapeaddress(const Array& params, bool fHelp)
 {
     if (fHelp || params.size() != 2)
         throw runtime_error(
-            "setscrapeaddress <staking address>, <address to stake to>\n"
+            "setscrapeaddress <staking address> <address to stake to>\n"
             "Set an auto scrape address to send stake rewards to from a given address."
         );
 


### PR DESCRIPTION
This would confuse a user into thinking they need to put a comma in between the `<staking address>` and the `<address to stake to>` when in fact this is invalid.