### PR TITLE
Change display logic for transaction table and scrape transactions

### DIFF
--- a/src/qt/transactionrecord.h
+++ b/src/qt/transactionrecord.h
@@ -70,7 +70,9 @@ public:
         RecvFromOther,
         SendToSelf,
         StakeMint,
-        ExternalScrape
+        ExternalScrape,
+        LocalScrape,
+        ScrapeToExternal
     };
 
     /** Number of confirmation needed for transaction */


### PR DESCRIPTION
All scrape transactions display the address that the reward went to.

"External scrape" type is set on transactions where the staking address
is not found in the receiving wallet.

"Local scrape" type is set on transactions where the staking address
and reward/scrape address are both found in the same wallet.

"Scraped to external" type is set on transactions where the reward
address was not found in the same wallet that did the stake
In the case of such transactions the reward coins are never present in
the staking wallet and therefore are always displayed in brackets.