### PR TITLE
Rework network config settings

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -206,13 +206,15 @@ bool static InitWarning(const std::string &str)
     return true;
 }
 
-bool static Bind(const CService &addr) {
+bool static Bind(const CService &addr, bool fError = true) {
     if (IsLimited(addr))
         return false;
     std::string strError;
-    if (!BindListenPort(addr, strError))
-        return InitError(strError);
-
+    if (!BindListenPort(addr, strError)) {
+        if (fError)
+            return InitError(strError);
+        return false;
+    }
     return true;
 }
 
@@ -229,19 +231,17 @@ std::string HelpMessage()
         "  -dblogsize=<n>        "   + _("Set database disk log size in megabytes (default: 100)") + "\n" +
         "  -timeout=<n>          "   + _("Specify connection timeout (in milliseconds)") + "\n" +
         "  -proxy=<ip:port>      "   + _("Connect through socks proxy") + "\n" +
-        "  -socks=<n>            "   + _("Select the version of socks proxy to use (4 or 5, 5 is default)") + "\n" +
-        "  -noproxy=<net>        "   + _("Do not use proxy for connections to network <net> (IPv4 or IPv6)") + "\n" +
+        "  -socks=<n>            "   + _("Select the version of socks proxy to use (4-5, default: 5)") + "\n" +
         "  -dns                  "   + _("Allow DNS lookups for -addnode, -seednode and -connect") + "\n" +
-        "  -proxydns             "   + _("Pass DNS requests to (SOCKS5) proxy") + "\n" +
         "  -port=<port>          "   + _("Listen for connections on <port> (default: 8998 or testnet: 9000)") + "\n" +
         "  -maxconnections=<n>   "   + _("Maintain at most <n> connections to peers (default: 125)") + "\n" +
         "  -addnode=<ip>         "   + _("Add a node to connect to and attempt to keep the connection open") + "\n" +
-        "  -connect=<ip>         "   + _("Connect only to the specified node") + "\n" +
+        "  -connect=<ip>         "   + _("Connect only to the specified node(s)") + "\n" +
         "  -seednode=<ip>        "   + _("Connect to a node to retrieve peer addresses, and disconnect") + "\n" +
         "  -externalip=<ip>      "   + _("Specify your own public address") + "\n" +
         "  -onlynet=<net>        "   + _("Only connect to nodes in network <net> (IPv4 or IPv6)") + "\n" +
-        "  -discover             "   + _("Try to discover public IP address (default: 1)") + "\n" +
-        "  -listen               "   + _("Accept connections from outside (default: 1)") + "\n" +
+        "  -discover             "   + _("Discover own IP address (default: 1 when listening and no -externalip)") + "\n" +
+        "  -listen               "   + _("Accept connections from outside (default: 1 if no -proxy or -connect)") + "\n" +
         "  -bind=<addr>          "   + _("Bind to given address. Use [host]:port notation for IPv6") + "\n" +
         "  -dnsseed              "   + _("Find peers using DNS lookup (default: 1)") + "\n" +
         "  -banscore=<n>         "   + _("Threshold for disconnecting misbehaving peers (default: 100)") + "\n" +
@@ -250,9 +250,9 @@ std::string HelpMessage()
         "  -maxsendbuffer=<n>    "   + _("Maximum per-connection send buffer, <n>*1000 bytes (default: 10000)") + "\n" +
 #ifdef USE_UPNP
 #if USE_UPNP
-        "  -upnp                 "   + _("Use Universal Plug and Play to map the listening port (default: 1)") + "\n" +
+        "  -upnp                 "   + _("Use UPnP to map the listening port (default: 1 when listening)") + "\n" +
 #else
-        "  -upnp                 "   + _("Use Universal Plug and Play to map the listening port (default: 0)") + "\n" +
+        "  -upnp                 "   + _("Use UPnP to map the listening port (default: 0)") + "\n" +
 #endif
 #endif
         "  -detachdb             "   + _("Detach block databases. Increases shutdown time (default: 0)") + "\n" +
@@ -340,24 +340,31 @@ bool AppInit2()
 
     // ********************************************************* Step 2: parameter interactions
 
+    if (mapArgs.count("-bind")) {
+        // when specifying an explicit binding address, you want to listen on it
+        // even when -connect or -proxy is specified
+        SoftSetBoolArg("-listen", true);
+    }
+
     if (mapArgs.count("-connect") && mapMultiArgs["-connect"].size() > 0) {
+        // when only connecting to trusted nodes, do not seed via DNS, or listen by default
         SoftSetBoolArg("-dnsseed", false);
         SoftSetBoolArg("-listen", false);
     }
 
-    // even in Tor mode, if -bind is specified, you really want -listen
-    if (mapArgs.count("-bind"))
-        SoftSetBoolArg("-listen", true);
-
-    bool fTor = (fUseProxy && addrProxy.GetPort() == 9050);
-    if (fTor)
-    {
-        // Use SoftSetBoolArg here so user can override any of these if they wish.
-        // Note: the GetBoolArg() calls for all of these must happen later.
+    if (mapArgs.count("-proxy")) {
+        // to protect privacy, do not listen by default if a proxy server is specified
         SoftSetBoolArg("-listen", false);
-        SoftSetBoolArg("-irc", false);
-        SoftSetBoolArg("-proxydns", true);
+    }
+
+    if (GetBoolArg("-listen", true)) {
+        // do not map ports or try to retrieve public IP when not listening (pointless)
         SoftSetBoolArg("-upnp", false);
+        SoftSetBoolArg("-discover", false);
+    }
+
+    if (mapArgs.count("-externalip")) {
+        // if an explicit public IP is specified, do not try to find others
         SoftSetBoolArg("-discover", false);
     }
 
@@ -476,31 +483,8 @@ bool AppInit2()
 
     // ********************************************************* Step 5: network initialization
 
-    if (mapArgs.count("-proxy"))
-    {
-        fUseProxy = true;
-        addrProxy = CService(mapArgs["-proxy"], 9050);
-        if (!addrProxy.IsValid())
-            return InitError(strprintf(_("Invalid -proxy address: '%s'"), mapArgs["-proxy"].c_str()));
-    }
+    int nSocksVersion = GetArg("-socks", 5);
 
-    if (mapArgs.count("-noproxy"))
-    {
-        BOOST_FOREACH(std::string snet, mapMultiArgs["-noproxy"]) {
-            enum Network net = ParseNetwork(snet);
-            if (net == NET_UNROUTABLE)
-                return InitError(strprintf(_("Unknown network specified in -noproxy: '%s'"), snet.c_str()));
-
-            SetNoProxy(net);
-        }
-    }
-
-    fNameLookup = GetBoolArg("-dns");
-    fProxyNameLookup = GetBoolArg("-proxydns");
-    if (fProxyNameLookup)
-        fNameLookup = true;
-    fNoListen = !GetBoolArg("-listen", true);
-    nSocksVersion = GetArg("-socks", 5);
     if (nSocksVersion != 4 && nSocksVersion != 5)
         return InitError(strprintf(_("Unknown -socks proxy version requested: %i"), nSocksVersion));
 
@@ -521,8 +505,29 @@ bool AppInit2()
         }
     }
 
-    BOOST_FOREACH(string strDest, mapMultiArgs["-seednode"])
-        AddOneShot(strDest);
+    if (mapArgs.count("-proxy")) {
+        CService addrProxy = CService(mapArgs["-proxy"], 9050);
+        if (!addrProxy.IsValid())
+            return InitError(strprintf(_("Invalid -proxy address: '%s'"), mapArgs["-proxy"].c_str()));
+
+        if (!IsLimited(NET_IPV4))
+            SetProxy(NET_IPV4, addrProxy, nSocksVersion);
+        if (nSocksVersion > 4) {
+#ifdef USE_IPV6
+            if (!IsLimited(NET_IPV6))
+                SetProxy(NET_IPV6, addrProxy, nSocksVersion);
+#endif
+            SetNameProxy(addrProxy, nSocksVersion);
+        }
+    }
+
+    // see Step 2: parameter interactions for more information about these
+    fNoListen = !GetBoolArg("-listen", true);
+    fDiscover = GetBoolArg("-discover", true);
+    fNameLookup = GetBoolArg("-dns", true);
+#ifdef USE_UPNP
+    fUseUPnP = GetBoolArg("-upnp", USE_UPNP);
+#endif
 
     bool fBound = false;
     if (!fNoListen)
@@ -539,15 +544,15 @@ bool AppInit2()
         } else {
             struct in_addr inaddr_any;
             inaddr_any.s_addr = INADDR_ANY;
-            if (!IsLimited(NET_IPV4))
-                fBound |= Bind(CService(inaddr_any, GetListenPort()));
 #ifdef USE_IPV6
             if (!IsLimited(NET_IPV6))
-                fBound |= Bind(CService(in6addr_any, GetListenPort()));
+                fBound |= Bind(CService(in6addr_any, GetListenPort()), false);
 #endif
+            if (!IsLimited(NET_IPV4))
+                fBound |= Bind(CService(inaddr_any, GetListenPort()), !fBound);
         }
         if (!fBound)
-            return InitError(_("Not listening on any port"));
+            return InitError(_("Failed to listen on any port. Use -listen=0 if you want this."));
     }
 
     if (mapArgs.count("-externalip"))
@@ -560,6 +565,9 @@ bool AppInit2()
             AddLocal(CService(strAddr, GetListenPort(), fNameLookup), LOCAL_MANUAL);
         }
     }
+
+    BOOST_FOREACH(string strDest, mapMultiArgs["-seednode"])
+        AddOneShot(strDest);
 
     // ********************************************************* Step 6: load blockchain
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2849,7 +2849,7 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv)
         if (!pfrom->fInbound)
         {
             // Advertise our address
-            if (!fNoListen && !fUseProxy && !IsInitialBlockDownload())
+            if (!fNoListen && !IsInitialBlockDownload())
             {
                 CAddress addr = GetLocalAddress(&pfrom->addr);
                 if (addr.IsRoutable())
@@ -3536,7 +3536,7 @@ bool SendMessages(CNode* pto, bool fSendTrickle)
                         pnode->setAddrKnown.clear();
 
                     // Rebroadcast our address
-                    if (!fNoListen && !fUseProxy)
+                    if (!fNoListen)
                     {
                         CAddress addr = GetLocalAddress(&pnode->addr);
                         if (addr.IsRoutable())

--- a/src/net.h
+++ b/src/net.h
@@ -38,7 +38,7 @@ void AddressCurrentlyConnected(const CService& addr);
 CNode* FindNode(const CNetAddr& ip);
 CNode* FindNode(const CService& ip);
 CNode* ConnectNode(CAddress addrConnect, const char *strDest = NULL, int64 nTimeout=0);
-void MapPort(bool fMapPort);
+void MapPort();
 unsigned short GetListenPort();
 bool BindListenPort(const CService &bindAddr, std::string& strError=REF(std::string()));
 void StartNode(void* parg);
@@ -92,6 +92,8 @@ enum threadId
 };
 
 extern bool fClient;
+extern bool fDiscover;
+extern bool fUseUPnP;
 extern uint64 nLocalServices;
 extern CAddress addrSeenByPeer;
 extern uint64 nLocalHostNonce;

--- a/src/netbase.h
+++ b/src/netbase.h
@@ -28,8 +28,8 @@ enum Network
     NET_MAX
 };
 
-enum Network ParseNetwork(std::string net);
-void SetNoProxy(enum Network net, bool fNoProxy = true);
+extern int nConnectTimeout;
+extern bool fNameLookup;
 
 /** IP address (IPv6, or IPv4 using mapped IPv6 range (::FFFF:0:0/96)) */
 class CNetAddr
@@ -132,6 +132,12 @@ class CService : public CNetAddr
             )
 };
 
+enum Network ParseNetwork(std::string net);
+bool SetProxy(enum Network net, CService addrProxy, int nSocksVersion = 5);
+bool GetProxy(enum Network net, CService &addrProxy);
+bool IsProxy(const CNetAddr &addr);
+bool SetNameProxy(CService addrProxy, int nSocksVersion = 5);
+bool GetNameProxy();
 bool LookupHost(const char *pszName, std::vector<CNetAddr>& vIP, unsigned int nMaxSolutions = 0, bool fAllowLookup = true);
 bool LookupHostNumeric(const char *pszName, std::vector<CNetAddr>& vIP, unsigned int nMaxSolutions = 0);
 bool Lookup(const char *pszName, CService& addr, int portDefault = 0, bool fAllowLookup = true);
@@ -139,12 +145,5 @@ bool Lookup(const char *pszName, std::vector<CService>& vAddr, int portDefault =
 bool LookupNumeric(const char *pszName, CService& addr, int portDefault = 0);
 bool ConnectSocket(const CService &addr, SOCKET& hSocketRet, int nTimeout = nConnectTimeout);
 bool ConnectSocketByName(CService &addr, SOCKET& hSocketRet, const char *pszDest, int portDefault = 0, int nTimeout = nConnectTimeout);
-
-// Settings
-extern int nSocksVersion;
-extern int fUseProxy;
-extern bool fProxyNameLookup;
-extern bool fNameLookup;
-extern CService addrProxy;
 
 #endif

--- a/src/qt/optionsdialog.cpp
+++ b/src/qt/optionsdialog.cpp
@@ -396,7 +396,7 @@ void NetworkOptionsPage::setMapper(MonitoredDataMapper *mapper)
 {
     // Map model to widgets
     mapper->addMapping(map_port_upnp, OptionsModel::MapPortUPnP);
-    mapper->addMapping(connect_socks4, OptionsModel::ConnectSOCKS4);
+    mapper->addMapping(connect_socks4, OptionsModel::ProxyUse);
     mapper->addMapping(proxy_ip, OptionsModel::ProxyIP);
     mapper->addMapping(proxy_port, OptionsModel::ProxyPort);
 }

--- a/src/qt/optionsmodel.cpp
+++ b/src/qt/optionsmodel.cpp
@@ -149,7 +149,7 @@ QVariant OptionsModel::data(const QModelIndex & index, int role) const
             if (GetProxy(NET_IPV4, addrProxy))
                 return QVariant(QString::fromStdString(addrProxy.ToStringIP()));
             else
-                return QVariant(QString::fromStdString("localhost"));
+                return QVariant(QString::fromStdString("127.0.0.1"));
         }
         case ProxyPort: {
             CService addrProxy;

--- a/src/qt/optionsmodel.cpp
+++ b/src/qt/optionsmodel.cpp
@@ -12,6 +12,29 @@ OptionsModel::OptionsModel(QObject *parent) :
     Init();
 }
 
+bool static ApplyProxySettings()
+{
+    QSettings settings;
+    CService addrProxy(settings.value("addrProxy", "127.0.0.1:9050").toString().toStdString());
+    int nSocksVersion(settings.value("nSocksVersion", 5).toInt());
+    if (!settings.value("fUseProxy", false).toBool()) {
+        addrProxy = CService();
+        nSocksVersion = 0;
+    }
+    if (nSocksVersion && !addrProxy.IsValid())
+        return false;
+    if (!IsLimited(NET_IPV4))
+        SetProxy(NET_IPV4, addrProxy, nSocksVersion);
+    if (nSocksVersion > 4) {
+#ifdef USE_IPV6
+        if (!IsLimited(NET_IPV6))
+            SetProxy(NET_IPV6, addrProxy, nSocksVersion);
+#endif
+        SetNameProxy(addrProxy, nSocksVersion);
+    }
+    return true;
+}
+
 void OptionsModel::Init()
 {
     QSettings settings;
@@ -76,20 +99,21 @@ bool OptionsModel::Upgrade()
         CAddress addrProxyAddress;
         if (walletdb.ReadSetting("addrProxy", addrProxyAddress))
         {
-            addrProxy = addrProxyAddress;
-            settings.setValue("addrProxy", addrProxy.ToStringIPPort().c_str());
+            settings.setValue("addrProxy", addrProxyAddress.ToStringIPPort().c_str());
             walletdb.EraseSetting("addrProxy");
         }
     }
     catch (std::ios_base::failure &e)
     {
         // 0.6.0rc1 saved this as a CService, which causes failure when parsing as a CAddress
+        CService addrProxy;
         if (walletdb.ReadSetting("addrProxy", addrProxy))
         {
             settings.setValue("addrProxy", addrProxy.ToStringIPPort().c_str());
             walletdb.EraseSetting("addrProxy");
         }
     }
+    ApplyProxySettings();
     Init();
 
     return true;
@@ -116,12 +140,24 @@ QVariant OptionsModel::data(const QModelIndex & index, int role) const
             return settings.value("fUseUPnP", GetBoolArg("-upnp", true));
         case MinimizeOnClose:
             return QVariant(fMinimizeOnClose);
-        case ConnectSOCKS4:
+        case ProxyUse:
             return settings.value("fUseProxy", false);
-        case ProxyIP:
-            return QVariant(QString::fromStdString(addrProxy.ToStringIP()));
-        case ProxyPort:
-            return QVariant(addrProxy.GetPort());
+        case ProxySocksVersion:
+            return settings.value("nSocksVersion", false);
+        case ProxyIP: {
+            CService addrProxy;
+            if (GetProxy(NET_IPV4, addrProxy))
+                return QVariant(QString::fromStdString(addrProxy.ToStringIP()));
+            else
+                return QVariant(QString::fromStdString("localhost"));
+        }
+        case ProxyPort: {
+            CService addrProxy;
+            if (GetProxy(NET_IPV4, addrProxy))
+                return QVariant(addrProxy.GetPort());
+            else
+                return 9050;
+        }
         case Fee:
             return QVariant(nTransactionFee);
         case DisplayUnit:
@@ -140,7 +176,6 @@ QVariant OptionsModel::data(const QModelIndex & index, int role) const
     }
     return QVariant();
 }
-
 bool OptionsModel::setData(const QModelIndex & index, const QVariant & value, int role)
 {
     bool successful = true; /* set to false on parse error */
@@ -158,27 +193,29 @@ bool OptionsModel::setData(const QModelIndex & index, const QVariant & value, in
             break;
         case MapPortUPnP:
             {
-                bool bUseUPnP = value.toBool();
-                settings.setValue("fUseUPnP", bUseUPnP);
-                MapPort(bUseUPnP);
+                fUseUPnP = value.toBool();
+                settings.setValue("fUseUPnP", fUseUPnP);
+                MapPort();
             }
             break;
         case MinimizeOnClose:
             fMinimizeOnClose = value.toBool();
             settings.setValue("fMinimizeOnClose", fMinimizeOnClose);
             break;
-        case ConnectSOCKS4:
-            fUseProxy = value.toBool();
-            settings.setValue("fUseProxy", fUseProxy);
+        case ProxyUse:
+            settings.setValue("fUseProxy", value.toBool());
+            ApplyProxySettings();
             break;
         case ProxyIP:
             {
-                // Use CAddress to parse and check IP
+                CService addrProxy("127.0.0.1", 9050);
+                GetProxy(NET_IPV4, addrProxy);
                 CNetAddr addr(value.toString().toStdString());
                 if (addr.IsValid())
                 {
                     addrProxy.SetIP(addr);
                     settings.setValue("addrProxy", addrProxy.ToStringIPPort().c_str());
+                    successful = ApplyProxySettings();
                 }
                 else
                 {
@@ -188,11 +225,14 @@ bool OptionsModel::setData(const QModelIndex & index, const QVariant & value, in
             break;
         case ProxyPort:
             {
+                CService addrProxy("127.0.0.1", 9050);
+                GetProxy(NET_IPV4, addrProxy);
                 int nPort = atoi(value.toString().toAscii().data());
                 if (nPort > 0 && nPort < std::numeric_limits<unsigned short>::max())
                 {
                     addrProxy.SetPort(nPort);
                     settings.setValue("addrProxy", addrProxy.ToStringIPPort().c_str());
+                    successful = ApplyProxySettings();
                 }
                 else
                 {

--- a/src/qt/optionsmodel.h
+++ b/src/qt/optionsmodel.h
@@ -20,7 +20,8 @@ public:
         MinimizeToTray, // bool
         MapPortUPnP, // bool
         MinimizeOnClose, // bool
-        ConnectSOCKS4, // bool
+        ProxyUse, // bool
+        ProxySocksVersion, // int
         ProxyIP, // QString
         ProxyPort, // QString
         Fee, // qint64

--- a/src/rpcwallet.cpp
+++ b/src/rpcwallet.cpp
@@ -63,6 +63,9 @@ Value getinfo(const Array& params, bool fHelp)
             "getinfo\n"
             "Returns an object containing various state info.");
 
+    CService addrProxy;
+    GetProxy(NET_IPV4, addrProxy);
+
     Object obj;
     obj.push_back(Pair("version",       FormatFullVersion()));
     obj.push_back(Pair("protocolversion",(int)PROTOCOL_VERSION));
@@ -73,7 +76,7 @@ Value getinfo(const Array& params, bool fHelp)
     obj.push_back(Pair("blocks",        (int)nBestHeight));
     obj.push_back(Pair("moneysupply",   ValueFromAmount(pindexBest->nMoneySupply)));
     obj.push_back(Pair("connections",   (int)vNodes.size()));
-    obj.push_back(Pair("proxy",         (fUseProxy ? addrProxy.ToStringIPPort() : string())));
+    obj.push_back(Pair("proxy",         (addrProxy.IsValid() ? addrProxy.ToStringIPPort() : string())));
     obj.push_back(Pair("ip",            addrSeenByPeer.ToStringIP()));
     obj.push_back(Pair("difficulty",    (double)GetDifficulty()));
     obj.push_back(Pair("testnet",       fTestNet));


### PR DESCRIPTION
The network base does no longer call GetArg directly. Instead, everything happens through a few globals and the SetProxy/SetNameProxy methods. These are called in init.cpp:AppInit2, and in Paycoin-Qt's optionsmodel.cpp.
