### PR TITLE
Correct a string accidentally referencing Bitcoin

### DIFF
--- a/src/qt/forms/rpcconsole.ui
+++ b/src/qt/forms/rpcconsole.ui
@@ -319,7 +319,7 @@
        <item row="16" column="0">
         <widget class="QPushButton" name="showCLOptionsButton">
          <property name="toolTip">
-          <string>Show the Bitcoin-Qt help message to get a list with possible Bitcoin command-line options.</string>
+          <string>Show the Paycoin-Qt help message to get a list with possible Paycoin command-line options.</string>
          </property>
          <property name="text">
           <string>&amp;Show</string>

--- a/src/qt/rpcconsole.h
+++ b/src/qt/rpcconsole.h
@@ -35,7 +35,7 @@ private slots:
     void on_tabWidget_currentChanged(int index);
     /** open the debug.log from the current datadir */
     void on_openDebugLogfileButton_clicked();
-    /** display messagebox with program parameters (same as bitcoin-qt --help) */
+    /** display messagebox with program parameters (same as paycoin-qt --help) */
     void on_showCLOptionsButton_clicked();
 
 public slots:


### PR DESCRIPTION
I mistakenly introduced this in my move class HelpMessageBox commit. Just fixing this now while it's on my mind.