### PR TITLE
Change Window title to "Paycoin - Wallet" / misc related renames

### DIFF
--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -54,7 +54,6 @@
 #include <QFileDialog>
 #include <QDesktopServices>
 #include <QTimer>
-
 #include <QDragEnterEvent>
 #include <QUrl>
 #include <QStyle>
@@ -75,7 +74,7 @@ BitcoinGUI::BitcoinGUI(QWidget *parent):
     spinnerFrame(0)
 {
     resize(850, 550);
-    setWindowTitle(tr("Paycoin Wallet"));
+    setWindowTitle(tr("Paycoin") + " - " + tr("Wallet"));
 #ifndef Q_OS_MAC
     setWindowIcon(QIcon(":icons/paycoin_icon"));
 #else

--- a/src/qt/forms/rpcconsole.ui
+++ b/src/qt/forms/rpcconsole.ui
@@ -11,7 +11,7 @@
    </rect>
   </property>
   <property name="windowTitle">
-   <string>Paycoin debug window</string>
+   <string>Paycoin - Debug window</string>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout_2">
    <item>
@@ -36,7 +36,7 @@
           </font>
          </property>
          <property name="text">
-          <string>Client</string>
+          <string>Paycoin Core</string>
          </property>
         </widget>
        </item>


### PR DESCRIPTION
- this helps user to not think our Client is called “Paycoin Wallet"
- change "Bitcoin debug window" to “Paycoin - Debug window"
- change "Client" in debug Window to “Paycoin Core"

(15 minutes)