### PR TITLE
Save main-geometry and some header data before closing the GUI

### DIFF
--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -21,6 +21,7 @@
 #include <QLocale>
 #include <QTranslator>
 #include <QLibraryInfo>
+#include <QSettings>
 
 #include <boost/interprocess/ipc/message_queue.hpp>
 #include <boost/algorithm/string/predicate.hpp>
@@ -309,6 +310,11 @@ int main(int argc, char *argv[])
             }
             // Shutdown the core and it's threads, but don't exit Bitcoin-Qt here
             Shutdown(NULL);
+
+            // Do this last to make sure all settings are written
+            QSettings settings;
+            if (settings.value("settings-version").toInt() != SETTINGS_VERSION)
+                settings.setValue("settings-version", SETTINGS_VERSION);
         }
         else
         {

--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -57,6 +57,7 @@
 #include <QDragEnterEvent>
 #include <QUrl>
 #include <QStyle>
+#include <QSettings>
 
 #include <iostream>
 
@@ -74,7 +75,13 @@ BitcoinGUI::BitcoinGUI(QWidget *parent):
     spinnerFrame(0)
 {
     resize(850, 550);
+    // Restore previous geometry (if any)
+    QSettings settings;
+    if (settings.contains("main-geometry"))
+        restoreGeometry(settings.value("main-geometry").toByteArray());
+
     setWindowTitle(tr("Paycoin") + " - " + tr("Wallet"));
+
 #ifndef Q_OS_MAC
     setWindowIcon(QIcon(":icons/paycoin_icon"));
 #else
@@ -193,6 +200,8 @@ BitcoinGUI::~BitcoinGUI()
 #ifdef Q_OS_MAC
     delete appMenuBar;
 #endif
+    QSettings settings;
+    settings.setValue("main-geometry", saveGeometry());
 }
 
 void BitcoinGUI::createActions()

--- a/src/qt/guiconstants.h
+++ b/src/qt/guiconstants.h
@@ -33,4 +33,6 @@ static const int TOOLTIP_WRAP_THRESHOLD = 80;
 /* Number of frames in spinner animation */
 #define SPINNER_FRAMES 35
 
+static const int SETTINGS_VERSION = 1;
+
 #endif // GUICONSTANTS_H

--- a/src/qt/mintingview.cpp
+++ b/src/qt/mintingview.cpp
@@ -17,6 +17,7 @@
 #include <QLineEdit>
 #include <QComboBox>
 #include <QMessageBox>
+#include <QSettings>
 
 MintingView::MintingView(QWidget *parent) :
     QWidget(parent), model(0), mintingView(0)
@@ -98,6 +99,11 @@ MintingView::MintingView(QWidget *parent) :
 
 }
 
+MintingView::~MintingView()
+{
+    QSettings settings;
+    settings.setValue("minting-headers", mintingView->horizontalHeader()->saveState());
+}
 
 void MintingView::setModel(WalletModel *model)
 {
@@ -117,18 +123,23 @@ void MintingView::setModel(WalletModel *model)
         mintingView->sortByColumn(MintingTableModel::CoinDay, Qt::DescendingOrder);
         mintingView->verticalHeader()->hide();
 
-        mintingView->horizontalHeader()->resizeSection(
+        QSettings settings;
+        if (settings.value("settings-version").toInt() == SETTINGS_VERSION) {
+            mintingView->horizontalHeader()->restoreState(settings.value("minting-headers").toByteArray());
+        } else {
+            mintingView->horizontalHeader()->resizeSection(
                 MintingTableModel::Address, 420);
-        mintingView->horizontalHeader()->setResizeMode(
+            mintingView->horizontalHeader()->setResizeMode(
                 MintingTableModel::TxHash, QHeaderView::Stretch);
-        mintingView->horizontalHeader()->resizeSection(
+            mintingView->horizontalHeader()->resizeSection(
                 MintingTableModel::Age, 120);
-        mintingView->horizontalHeader()->resizeSection(
+            mintingView->horizontalHeader()->resizeSection(
                 MintingTableModel::Balance, 120);
-        mintingView->horizontalHeader()->resizeSection(
+            mintingView->horizontalHeader()->resizeSection(
                 MintingTableModel::CoinDay,120);
-        mintingView->horizontalHeader()->resizeSection(
+            mintingView->horizontalHeader()->resizeSection(
                 MintingTableModel::MintProbability, 160);
+        }
     }
 }
 

--- a/src/qt/mintingview.h
+++ b/src/qt/mintingview.h
@@ -17,6 +17,7 @@ class MintingView : public QWidget
     Q_OBJECT
 public:
     explicit MintingView(QWidget *parent = 0);
+    ~MintingView();
     void setModel(WalletModel *model);
 
     enum MintingEnum

--- a/src/qt/transactionview.cpp
+++ b/src/qt/transactionview.cpp
@@ -11,6 +11,7 @@
 #include "editaddressdialog.h"
 #include "optionsmodel.h"
 #include "guiutil.h"
+#include "guiconstants.h"
 #include "wallet.h"
 
 #include <QScrollBar>
@@ -30,6 +31,7 @@
 #include <QDateTimeEdit>
 #include <QDesktopServices>
 #include <QUrl>
+#include <QSettings>
 
 TransactionView::TransactionView(QWidget *parent) :
     QWidget(parent), model(0), transactionProxyModel(0),
@@ -165,6 +167,12 @@ TransactionView::TransactionView(QWidget *parent) :
     connect(clearOrphansAction, SIGNAL(triggered()), this, SLOT(clearOrphans()));
 }
 
+TransactionView::~TransactionView()
+{
+    QSettings settings;
+    settings.setValue("transaction-headers", transactionView->horizontalHeader()->saveState());
+}
+
 void TransactionView::setModel(WalletModel *model)
 {
     this->model = model;
@@ -186,16 +194,21 @@ void TransactionView::setModel(WalletModel *model)
         transactionView->sortByColumn(TransactionTableModel::Date, Qt::DescendingOrder);
         transactionView->verticalHeader()->hide();
 
-        transactionView->horizontalHeader()->resizeSection(
+        QSettings settings;
+        if (settings.value("settings-version").toInt() == SETTINGS_VERSION) {
+            transactionView->horizontalHeader()->restoreState(settings.value("transaction-headers").toByteArray());
+        } else {
+            transactionView->horizontalHeader()->resizeSection(
                 TransactionTableModel::Status, 23);
-        transactionView->horizontalHeader()->resizeSection(
+            transactionView->horizontalHeader()->resizeSection(
                 TransactionTableModel::Date, 120);
-        transactionView->horizontalHeader()->resizeSection(
+            transactionView->horizontalHeader()->resizeSection(
                 TransactionTableModel::Type, 120);
-        transactionView->horizontalHeader()->setResizeMode(
+            transactionView->horizontalHeader()->setResizeMode(
                 TransactionTableModel::ToAddress, QHeaderView::Stretch);
-        transactionView->horizontalHeader()->resizeSection(
+            transactionView->horizontalHeader()->resizeSection(
                 TransactionTableModel::Amount, 100);
+        }
     }
 }
 

--- a/src/qt/transactionview.h
+++ b/src/qt/transactionview.h
@@ -24,6 +24,7 @@ class TransactionView : public QWidget
     Q_OBJECT
 public:
     explicit TransactionView(QWidget *parent = 0);
+    ~TransactionView();
 
     void setModel(WalletModel *model);
 


### PR DESCRIPTION
This will restore the physical geometry of the main window upon reopening

It will also retain and restore the column header sizes for the minting
tab and the transactions tab; do to the nature of the address book (in
that both receiving page and the address book page use the same header
object) we cannot restore this without breaking scrape address display
(I figure this is safe cause there's only 2 or 3 entries on both those
tabs and they fit pretty well in all states).

This resolves #308