### PR TITLE
Make the minting table's address display match the transaction table

### DIFF
--- a/src/qt/mintingtablemodel.cpp
+++ b/src/qt/mintingtablemodel.cpp
@@ -387,7 +387,16 @@ QString MintingTableModel::formatDayToMint(KernelRecord *wtx) const
 
 QString MintingTableModel::formatTxAddress(const KernelRecord *wtx, bool tooltip) const
 {
-    return QString::fromStdString(wtx->address);
+    QString label = walletModel->getAddressTableModel()->labelForAddress(QString::fromStdString(wtx->address));
+    QString description;
+    if (!label.isEmpty()) {
+        description += label + QString(" ");
+    }
+    if (label.isEmpty() || walletModel->getOptionsModel()->getDisplayAddresses() || tooltip) {
+        description += QString("(") + QString::fromStdString(wtx->address) + QString(")");
+    }
+
+    return description;
 }
 
 QString MintingTableModel::formatTxHash(const KernelRecord *wtx) const


### PR DESCRIPTION
puts the addresses in parenthesis and puts the label before it.

this resolves #305