### PR TITLE
Revert "Remove spent transactions from the minting table model."

### DIFF
--- a/src/qt/mintingtablemodel.cpp
+++ b/src/qt/mintingtablemodel.cpp
@@ -151,21 +151,9 @@ public:
                     cachedWallet.erase(lower, upper);
                     parent->endRemoveRows();
                 }
-
                 else if(inWallet && inModel)
                 {
-                    // Remove spent transactions from the table model.
-                    std::vector<KernelRecord> maybeRemove =
-                            KernelRecord::decomposeOutput(wallet, mi->second);
-
-                    BOOST_FOREACH(const KernelRecord &rec, maybeRemove)
-                    {
-                        if(rec.spent) {
-                            parent->beginRemoveRows(QModelIndex(), lowerIndex, upperIndex-1);
-                            cachedWallet.erase(lower, upper);
-                            parent->endRemoveRows();
-                        }
-                    }
+                    // Updated -- nothing to do, status update will take care of this
                 }
             }
         }
@@ -457,3 +445,4 @@ QModelIndex MintingTableModel::index(int row, int column, const QModelIndex &par
         return QModelIndex();
     }
 }
+


### PR DESCRIPTION
This reverts commit 02005297a1f87d633deba98e690473097e1b50be.

This is causing a random double free in the memory which is crashing on some transactions (mainly in windows), revert it until we can figure out a better way to do this.

This reopens #17 
Fixes #297, fixes #456, fixes #457 and fixes #463