### PR TITLE
Fix microprime staking

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -999,18 +999,11 @@ int64 GetProofOfStakeReward(int64 nCoinAge, unsigned int nTime, int primeNodeRat
     int64 nSubsidy = 0;
     int64 nRewardCoinYear = 0;  // creation amount per coin-year
 
-    if (primeNodeRate == 0)
+    if (primeNodeRate == 0) {
         nRewardCoinYear = 5 * CENT;
-    else if (primeNodeRate == 10)
-        nRewardCoinYear = 10 * CENT;
-    else if (primeNodeRate == 20)
-        nRewardCoinYear = 20 * CENT;
-    else if (primeNodeRate == 25)
-        nRewardCoinYear = 25 * CENT;
-    else if (primeNodeRate == 100)
-        nRewardCoinYear = 100 * CENT;
-    else if (primeNodeRate == 350)
-        nRewardCoinYear = 350 * CENT;
+    } else {
+        nRewardCoinYear = primeNodeRate * CENT;
+    }
 
     nSubsidy = nCoinAge * nRewardCoinYear * 33 / (365 * 33 + 8);
 


### PR DESCRIPTION
Currently microprimes are supposed to be staking at 15%...

In the future their rate will be calculated dynamically,
replace hard-coded rate checks with basic multiplication.

DANGER: this is forking code.