### PR TITLE
Replace testnet DNS Seed with a working one

### DIFF
--- a/src/net.cpp
+++ b/src/net.cpp
@@ -1182,7 +1182,8 @@ static const char *strDNSSeed[][2] = {
     {"dnsseed.paycoin.com", "dnsseed.paycoin.com"},
     {"dnsseed.paycoinfoundation.org", "dnsseed.paycoinfoundation.org"},
     {"dnsseed.xpydev.org", "dnsseed.xpydev.org"},
-    {"tseed.paycoin.com", "tseed.paycoin.com"}
+    {"tseed.paycoin.com", "tseed.paycoin.com"},
+    {"testnet-seed.paycoin.mitchellcash.com", "testnet-seed.paycoin.mitchellcash.com"} // Mitchell Cash
 };
 
 void ThreadDNSAddressSeed(void* parg)


### PR DESCRIPTION
Fixes #443.

I replaced the Paycoin Testnet Seed but if there is intention to turn this node back on let me know and I will leave it in there.

(30 minutes)