### PR TITLE
Better defined RPC and HTTP errors

### DIFF
--- a/src/bitcoinrpc.h
+++ b/src/bitcoinrpc.h
@@ -17,6 +17,68 @@ class CReserveKey;
 #include "json/json_spirit_writer_template.h"
 #include "json/json_spirit_utils.h"
 
+//! HTTP status codes
+enum HTTPStatusCode
+{
+    HTTP_OK                    = 200,
+    HTTP_BAD_REQUEST           = 400,
+    HTTP_UNAUTHORIZED          = 401,
+    HTTP_FORBIDDEN             = 403,
+    HTTP_NOT_FOUND             = 404,
+    HTTP_BAD_METHOD            = 405,
+    HTTP_INTERNAL_SERVER_ERROR = 500,
+    HTTP_SERVICE_UNAVAILABLE   = 503,
+};
+
+//! Bitcoin RPC error codes
+enum RPCErrorCode
+{
+    //! Standard JSON-RPC 2.0 errors
+    RPC_INVALID_REQUEST  = -32600,
+    RPC_METHOD_NOT_FOUND = -32601,
+    RPC_INVALID_PARAMS   = -32602,
+    RPC_INTERNAL_ERROR   = -32603,
+    RPC_PARSE_ERROR      = -32700,
+
+    //! General application defined errors
+    RPC_MISC_ERROR                  = -1,  //! std::exception thrown in command handling
+    RPC_FORBIDDEN_BY_SAFE_MODE      = -2,  //! Server is in safe mode, and command is not allowed in safe mode
+    RPC_TYPE_ERROR                  = -3,  //! Unexpected type was passed as parameter
+    RPC_INVALID_ADDRESS_OR_KEY      = -5,  //! Invalid address or key
+    RPC_OUT_OF_MEMORY               = -7,  //! Ran out of memory during operation
+    RPC_INVALID_PARAMETER           = -8,  //! Invalid, missing or duplicate parameter
+    RPC_DATABASE_ERROR              = -20, //! Database error
+    RPC_DESERIALIZATION_ERROR       = -22, //! Error parsing or validating structure in raw format
+    RPC_VERIFY_ERROR                = -25, //! General error during transaction or block submission
+    RPC_VERIFY_REJECTED             = -26, //! Transaction or block was rejected by network rules
+    RPC_VERIFY_ALREADY_IN_CHAIN     = -27, //! Transaction already in chain
+    RPC_IN_WARMUP                   = -28, //! Client still warming up
+
+    //! Aliases for backward compatibility
+    RPC_TRANSACTION_ERROR           = RPC_VERIFY_ERROR,
+    RPC_TRANSACTION_REJECTED        = RPC_VERIFY_REJECTED,
+    RPC_TRANSACTION_ALREADY_IN_CHAIN= RPC_VERIFY_ALREADY_IN_CHAIN,
+
+    //! P2P client errors
+    RPC_CLIENT_NOT_CONNECTED        = -9,  //! Bitcoin is not connected
+    RPC_CLIENT_IN_INITIAL_DOWNLOAD  = -10, //! Still downloading initial blocks
+    RPC_CLIENT_NODE_ALREADY_ADDED   = -23, //! Node is already added
+    RPC_CLIENT_NODE_NOT_ADDED       = -24, //! Node has not been added before
+    RPC_CLIENT_NODE_NOT_CONNECTED   = -29, //! Node to disconnect not found in connected nodes
+    RPC_CLIENT_INVALID_IP_OR_SUBNET = -30, //! Invalid IP/Subnet
+
+    //! Wallet errors
+    RPC_WALLET_ERROR                = -4,  //! Unspecified problem with wallet (key not found etc.)
+    RPC_WALLET_INSUFFICIENT_FUNDS   = -6,  //! Not enough funds in wallet or account
+    RPC_WALLET_INVALID_ACCOUNT_NAME = -11, //! Invalid account name
+    RPC_WALLET_KEYPOOL_RAN_OUT      = -12, //! Keypool ran out, call keypoolrefill first
+    RPC_WALLET_UNLOCK_NEEDED        = -13, //! Enter the wallet passphrase with walletpassphrase first
+    RPC_WALLET_PASSPHRASE_INCORRECT = -14, //! The wallet passphrase entered was incorrect
+    RPC_WALLET_WRONG_ENC_STATE      = -15, //! Command given in wrong wallet encryption state (encrypting an encrypted wallet etc.)
+    RPC_WALLET_ENCRYPTION_FAILED    = -16, //! Failed to encrypt the wallet
+    RPC_WALLET_ALREADY_UNLOCKED     = -17, //! Wallet is already unlocked
+};
+
 void ThreadRPCServer(void* parg);
 int CommandLineRPC(int argc, char *argv[]);
 

--- a/src/rpcblockchain.cpp
+++ b/src/rpcblockchain.cpp
@@ -137,7 +137,7 @@ Value getblockhash(const Array& params, bool fHelp)
 
     int nHeight = params[0].get_int();
     if (nHeight < 0 || nHeight > nBestHeight)
-        throw runtime_error("Block number out of range.");
+        throw JSONRPCError(RPC_INVALID_PARAMETER, "Block number out of range.");
 
     CBlockIndex* pblockindex = FindBlockByHeight(nHeight);
     return pblockindex->phashBlock->GetHex();
@@ -156,7 +156,7 @@ Value getblock(const Array& params, bool fHelp)
     uint256 hash(strHash);
 
     if (mapBlockIndex.count(hash) == 0)
-        throw JSONRPCError(-5, "Block not found");
+        throw JSONRPCError(RPC_INVALID_PARAMETER, "Block not found");
 
     CBlock block;
     CBlockIndex* pblockindex = mapBlockIndex[hash];

--- a/src/rpcdump.cpp
+++ b/src/rpcdump.cpp
@@ -20,8 +20,6 @@
 using namespace json_spirit;
 using namespace std;
 
-extern Object JSONRPCError(int code, const string& message);
-
 class CTxDump
 {
 public:
@@ -54,11 +52,11 @@ Value importprivkey(const Array& params, bool fHelp)
     CBitcoinSecret vchSecret;
     bool fGood = vchSecret.SetString(strSecret);
 
-    if (!fGood) throw JSONRPCError(-5,"Invalid private key");
+    if (!fGood) throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY,"Invalid private key");
     if (pwalletMain->IsLocked())
-        throw JSONRPCError(-13, "Error: Please enter the wallet passphrase with walletpassphrase first.");
+        throw JSONRPCError(RPC_WALLET_UNLOCK_NEEDED, "Error: Please enter the wallet passphrase with walletpassphrase first.");
     if (fWalletUnlockMintOnly) // paycoin: no importprivkey in mint-only mode
-        throw JSONRPCError(-102, "Wallet is unlocked for minting only (unlock with walletpassphrase).");
+        throw JSONRPCError(RPC_WALLET_WRONG_ENC_STATE, "Wallet is unlocked for minting only (unlock with walletpassphrase).");
 
     CKey key;
     bool fCompressed;
@@ -72,7 +70,7 @@ Value importprivkey(const Array& params, bool fHelp)
         pwalletMain->SetAddressBookName(vchAddress, strLabel);
 
         if (!pwalletMain->AddKey(key))
-            throw JSONRPCError(-4,"Error adding key to wallet");
+            throw JSONRPCError(RPC_WALLET_ERROR, "Error adding key to wallet");
 
         pwalletMain->ScanForWalletTransactions(pindexGenesisBlock, true);
         pwalletMain->ReacceptWalletTransactions();
@@ -93,17 +91,17 @@ Value dumpprivkey(const Array& params, bool fHelp)
     string strAddress = params[0].get_str();
     CBitcoinAddress address;
     if (!address.SetString(strAddress))
-        throw JSONRPCError(-5, "Invalid Paycoin address");
+        throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Invalid Paycoin address");
     if (pwalletMain->IsLocked())
-        throw JSONRPCError(-13, "Error: Please enter the wallet passphrase with walletpassphrase first.");
+        throw JSONRPCError(RPC_WALLET_UNLOCK_NEEDED, "Error: Please enter the wallet passphrase with walletpassphrase first.");
     if (fWalletUnlockMintOnly) // paycoin: no dumpprivkey in mint-only mode
-        throw JSONRPCError(-102, "Wallet is unlocked for minting only (unlock with walletpassphrase).");
+        throw JSONRPCError(RPC_WALLET_WRONG_ENC_STATE, "Wallet is unlocked for minting only (unlock with walletpassphrase).");
     CKeyID keyID;
     if (!address.GetKeyID(keyID))
-        throw JSONRPCError(-3, "Address does not refer to a key");
+        throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Address does not refer to a key");
     CSecret vchSecret;
     bool fCompressed;
     if (!pwalletMain->GetSecret(keyID, vchSecret, fCompressed))
-        throw JSONRPCError(-4,"Private key for address " + strAddress + " is not known");
+        throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Private key for address " + strAddress + " is not known");
     return CBitcoinSecret(vchSecret, fCompressed).ToString();
 }

--- a/src/rpcnet.cpp
+++ b/src/rpcnet.cpp
@@ -108,11 +108,9 @@ Value sendalert(const Array& params, bool fHelp)
     vector<unsigned char> vchPrivKey = ParseHex(params[1].get_str());
     key.SetPrivKey(CPrivKey(vchPrivKey.begin(), vchPrivKey.end())); // if key is not correct openssl may crash
     if (!key.Sign(Hash(alert.vchMsg.begin(), alert.vchMsg.end()), alert.vchSig))
-        throw runtime_error(
-            "Unable to sign alert, check private key?\n");
+        throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Unable to sign alert, check private key?\n");
     if(!alert.ProcessAlert())
-        throw runtime_error(
-            "Failed to process alert.\n");
+        throw JSONRPCError(RPC_MISC_ERROR, "Failed to process alert.\n");
     // Relay alert
     {
         LOCK(cs_vNodes);

--- a/src/rpcrawtransaction.cpp
+++ b/src/rpcrawtransaction.cpp
@@ -190,7 +190,7 @@ Value getrawtransaction(const Array& params, bool fHelp)
     CTransaction tx;
     uint256 hashBlock = 0;
     if (!GetTransaction(hash, tx, hashBlock))
-        throw JSONRPCError(-5, "No information available about transaction");
+        throw JSONRPCError(RPC_WALLET_ERROR, "No information available about transaction");
 
     CDataStream ssTx(SER_NETWORK, PROTOCOL_VERSION);
     ssTx << tx;
@@ -232,9 +232,9 @@ Value listunspent(const Array& params, bool fHelp)
         {
             CBitcoinAddress address(input.get_str());
             if (!address.IsValid())
-                throw JSONRPCError(-5, string("Invalid Bitcoin address: ")+input.get_str());
+                throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, string("Invalid Paycoin address: ")+input.get_str());
             if (setAddress.count(address))
-                throw JSONRPCError(-8, string("Invalid parameter, duplicated address: ")+input.get_str());
+                throw JSONRPCError(RPC_INVALID_PARAMETER, string("Invalid parameter, duplicated address: ")+input.get_str());
            setAddress.insert(address);
         }
     }
@@ -301,17 +301,17 @@ Value createrawtransaction(const Array& params, bool fHelp)
 
         const Value& txid_v = find_value(o, "txid");
         if (txid_v.type() != str_type)
-            throw JSONRPCError(-8, "Invalid parameter, missing txid key");
+            throw JSONRPCError(RPC_INVALID_PARAMETER, "Invalid parameter, missing txid key");
         string txid = txid_v.get_str();
         if (!IsHex(txid))
-            throw JSONRPCError(-8, "Invalid parameter, expected hex txid");
+            throw JSONRPCError(RPC_INVALID_PARAMETER, "Invalid parameter, expected hex txid");
 
         const Value& vout_v = find_value(o, "vout");
         if (vout_v.type() != int_type)
-            throw JSONRPCError(-8, "Invalid parameter, missing vout key");
+            throw JSONRPCError(RPC_INVALID_PARAMETER, "Invalid parameter, missing vout key");
         int nOutput = vout_v.get_int();
         if (nOutput < 0)
-            throw JSONRPCError(-8, "Invalid parameter, vout must be positive");
+            throw JSONRPCError(RPC_INVALID_PARAMETER, "Invalid parameter, vout must be positive");
 
         CTxIn in(COutPoint(uint256(txid), nOutput));
         rawTx.vin.push_back(in);
@@ -322,10 +322,10 @@ Value createrawtransaction(const Array& params, bool fHelp)
     {
         CBitcoinAddress address(s.name_);
         if (!address.IsValid())
-            throw JSONRPCError(-5, string("Invalid Bitcoin address: ")+s.name_);
+            throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, string("Invalid Paycoin address: ")+s.name_);
 
         if (setAddress.count(address))
-            throw JSONRPCError(-8, string("Invalid parameter, duplicated address: ")+s.name_);
+            throw JSONRPCError(RPC_INVALID_PARAMETER, string("Invalid parameter, duplicated address: ")+s.name_);
         setAddress.insert(address);
 
         CScript scriptPubKey;
@@ -355,7 +355,7 @@ Value decoderawtransaction(const Array& params, bool fHelp)
         ssData >> tx;
     }
     catch (std::exception &e) {
-        throw JSONRPCError(-22, "TX decode failed");
+        throw JSONRPCError(RPC_DESERIALIZATION_ERROR, "TX decode failed");
     }
 
     Object result;
@@ -391,12 +391,12 @@ Value signrawtransaction(const Array& params, bool fHelp)
             txVariants.push_back(tx);
         }
         catch (std::exception &e) {
-            throw JSONRPCError(-22, "TX decode failed");
+            throw JSONRPCError(RPC_DESERIALIZATION_ERROR, "TX decode failed");
         }
     }
 
     if (txVariants.empty())
-        throw JSONRPCError(-22, "Missing transaction");
+        throw JSONRPCError(RPC_WALLET_ERROR, "Missing transaction");
 
     // mergedTx will end up with all the signatures; it
     // starts as a clone of the rawtx:
@@ -437,7 +437,7 @@ Value signrawtransaction(const Array& params, bool fHelp)
             CBitcoinSecret vchSecret;
             bool fGood = vchSecret.SetString(k.get_str());
             if (!fGood)
-                throw JSONRPCError(-5,"Invalid private key");
+                throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Invalid private key");
             CKey key;
             bool fCompressed;
             CSecret secret = vchSecret.GetSecret(fCompressed);
@@ -446,7 +446,7 @@ Value signrawtransaction(const Array& params, bool fHelp)
         }
     }
     else if(pwalletMain->IsCrypted())
-      throw runtime_error("The wallet must be unlocked with walletpassphrase first");
+      throw JSONRPCError(RPC_WALLET_UNLOCK_NEEDED, "The wallet must be unlocked with walletpassphrase first");
 
     // Add previous txouts given in the RPC call:
     if (params.size() > 1 && params[1].type() != null_type)
@@ -455,23 +455,23 @@ Value signrawtransaction(const Array& params, bool fHelp)
         BOOST_FOREACH(Value& p, prevTxs)
         {
             if (p.type() != obj_type)
-                throw JSONRPCError(-22, "expected object with {\"txid'\",\"vout\",\"scriptPubKey\"}");
+                throw JSONRPCError(RPC_DESERIALIZATION_ERROR, "expected object with {\"txid'\",\"vout\",\"scriptPubKey\"}");
 
             Object prevOut = p.get_obj();
 
             string txidHex = find_value(prevOut, "txid").get_str();
             if (!IsHex(txidHex))
-                throw JSONRPCError(-22, "txid must be hexadecimal");
+                throw JSONRPCError(RPC_DESERIALIZATION_ERROR, "txid must be hexadecimal");
             uint256 txid;
             txid.SetHex(txidHex);
 
             int nOut = find_value(prevOut, "vout").get_int();
             if (nOut < 0)
-                throw JSONRPCError(-22, "vout must be positive");
+                throw JSONRPCError(RPC_DESERIALIZATION_ERROR, "vout must be positive");
 
             string pkHex = find_value(prevOut, "scriptPubKey").get_str();
             if (!IsHex(pkHex))
-                throw JSONRPCError(-22, "scriptPubKey must be hexadecimal");
+                throw JSONRPCError(RPC_DESERIALIZATION_ERROR, "scriptPubKey must be hexadecimal");
             vector<unsigned char> pkData(ParseHex(pkHex));
             CScript scriptPubKey(pkData.begin(), pkData.end());
 
@@ -484,7 +484,7 @@ Value signrawtransaction(const Array& params, bool fHelp)
                     string err("Previous output scriptPubKey mismatch:\n");
                     err = err + mapPrevOut[outpoint].ToString() + "\nvs:\n"+
                         scriptPubKey.ToString();
-                    throw JSONRPCError(-22, err);
+                    throw JSONRPCError(RPC_DESERIALIZATION_ERROR, err);
                 }
             }
             else
@@ -523,7 +523,7 @@ Value signrawtransaction(const Array& params, bool fHelp)
         if (mapSigHashValues.count(strHashType))
             nHashType = mapSigHashValues[strHashType];
         else
-            throw JSONRPCError(-8, "Invalid sighash param");
+            throw JSONRPCError(RPC_INVALID_PARAMETER, "Invalid sighash param");
     }
 
     bool fHashSingle = ((nHashType & ~SIGHASH_ANYONECANPAY) == SIGHASH_SINGLE);
@@ -583,7 +583,7 @@ Value sendrawtransaction(const Array& params, bool fHelp)
         ssData >> tx;
     }
     catch (std::exception &e) {
-        throw JSONRPCError(-22, "TX decode failed");
+        throw JSONRPCError(RPC_DESERIALIZATION_ERROR, "TX decode failed");
     }
     uint256 hashTx = tx.GetHash();
 
@@ -594,7 +594,7 @@ Value sendrawtransaction(const Array& params, bool fHelp)
     if (GetTransaction(hashTx, existingTx, hashBlock))
     {
         if (hashBlock != 0)
-            throw JSONRPCError(-5, string("transaction already in block ")+hashBlock.GetHex());
+            throw JSONRPCError(RPC_VERIFY_ALREADY_IN_CHAIN, string("transaction already in block ")+hashBlock.GetHex());
         // Not in block, but already in the memory pool; will drop
         // through to re-relay it.
     }
@@ -603,7 +603,7 @@ Value sendrawtransaction(const Array& params, bool fHelp)
         // push to local node
         CTxDB txdb("r");
         if (!tx.AcceptToMemoryPool(txdb, fCheckInputs))
-            throw JSONRPCError(-22, "TX rejected");
+            throw JSONRPCError(RPC_VERIFY_REJECTED, "TX rejected");
 
         SyncWithWallets(tx, NULL, true);
     }

--- a/src/scrapesdb.cpp
+++ b/src/scrapesdb.cpp
@@ -21,7 +21,7 @@ Value setscrapeaddress(const Array& params, bool fHelp)
     }
 
     if (pwalletMain->IsLocked())
-        throw JSONRPCError(-13, "Error: Please enter the wallet passphrase with walletpassphrase first.");
+        throw JSONRPCError(RPC_WALLET_UNLOCK_NEEDED, "Error: Please enter the wallet passphrase with walletpassphrase first.");
 
     string strAddress = params[0].get_str();
     CBitcoinAddress address(strAddress);
@@ -29,16 +29,16 @@ Value setscrapeaddress(const Array& params, bool fHelp)
     CBitcoinAddress scrapeAddress(strScrapeAddress);
 
     if (!address.IsValid())
-        throw JSONRPCError(-5, "Invalid Paycoin address.");
+        throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Invalid Paycoin address.");
 
     if (address.Get() == scrapeAddress.Get())
-        throw JSONRPCError(-1, "Cannot set scrape address to the same as staking address.");
+        throw JSONRPCError(RPC_WALLET_ERROR, "Cannot set scrape address to the same as staking address.");
 
     if (!IsMine(*pwalletMain, address.Get()))
-        throw JSONRPCError(-1, "Staking address must be in wallet.");
+        throw JSONRPCError(RPC_WALLET_ERROR, "Staking address must be in wallet.");
 
     if (!scrapeAddress.IsValid())
-        throw JSONRPCError(-5, "Invalid scrape address.");
+        throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Invalid scrape address.");
 
     string oldScrapeAddress;
     bool warn = false;
@@ -59,7 +59,7 @@ Value setscrapeaddress(const Array& params, bool fHelp)
     }
 
     // This should never happen.
-    throw JSONRPCError(-1, "setscrapeaddress: unknown error");
+    throw JSONRPCError(RPC_MISC_ERROR, "setscrapeaddress: unknown error");
 }
 
 Value getscrapeaddress(const Array& params, bool fHelp)
@@ -74,16 +74,16 @@ Value getscrapeaddress(const Array& params, bool fHelp)
     CBitcoinAddress address(strAddress);
 
     if (!address.IsValid())
-        throw JSONRPCError(-5, "Invalid Paycoin address.");
+        throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Invalid Paycoin address.");
 
     if (!IsMine(*pwalletMain, address.Get()))
-        throw JSONRPCError(-1, "Staking address must be in wallet.");
+        throw JSONRPCError(RPC_WALLET_ERROR, "Staking address must be in wallet.");
 
     string strScrapeAddress;
     if (!scrapesDB->ReadScrapeAddress(strAddress, strScrapeAddress)) {
         string ret = "No scrape address set for address ";
         ret += strAddress;
-        throw JSONRPCError(-1, ret);
+        throw JSONRPCError(RPC_WALLET_ERROR, ret);
     }
 
     Object obj;
@@ -116,21 +116,21 @@ Value deletescrapeaddress(const Array& params, bool fHelp)
     }
 
     if (pwalletMain->IsLocked())
-        throw JSONRPCError(-13, "Error: Please enter the wallet passphrase with walletpassphrase first.");
+        throw JSONRPCError(RPC_WALLET_UNLOCK_NEEDED, "Error: Please enter the wallet passphrase with walletpassphrase first.");
 
     string strAddress = params[0].get_str();
     CBitcoinAddress address(strAddress);
 
     if (!address.IsValid())
-        throw JSONRPCError(-5, "Invalid Paycoin address.");
+        throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Invalid Paycoin address.");
 
     if (!IsMine(*pwalletMain, address.Get()))
-        throw JSONRPCError(-1, "Staking address must be in wallet.");
+        throw JSONRPCError(RPC_WALLET_ERROR, "Staking address must be in wallet.");
 
     if (!scrapesDB->HasScrapeAddress(strAddress)) {
         string ret = "No scrape address set for address ";
         ret += strAddress;
-        throw JSONRPCError(-1, ret);
+        throw JSONRPCError(RPC_WALLET_ERROR, ret);
     }
 
     return scrapesDB->EraseScrapeAddress(strAddress);

--- a/src/test/rpc_tests.cpp
+++ b/src/test/rpc_tests.cpp
@@ -46,18 +46,18 @@ BOOST_AUTO_TEST_CASE(rpc_addmultisig)
     address.SetString(v.get_str());
     BOOST_CHECK(address.IsValid() && address.IsScript());
 
-    BOOST_CHECK_THROW(addmultisig(createArgs(0), false), runtime_error);
-    BOOST_CHECK_THROW(addmultisig(createArgs(1), false), runtime_error);
-    BOOST_CHECK_THROW(addmultisig(createArgs(2, address1Hex), false), runtime_error);
+    BOOST_CHECK_THROW(addmultisig(createArgs(0), false), Object);
+    BOOST_CHECK_THROW(addmultisig(createArgs(1), false), Object);
+    BOOST_CHECK_THROW(addmultisig(createArgs(2, address1Hex), false), Object);
 
-    BOOST_CHECK_THROW(addmultisig(createArgs(1, ""), false), runtime_error);
-    BOOST_CHECK_THROW(addmultisig(createArgs(1, "NotAValidPubkey"), false), runtime_error);
+    BOOST_CHECK_THROW(addmultisig(createArgs(1, ""), false), Object);
+    BOOST_CHECK_THROW(addmultisig(createArgs(1, "NotAValidPubkey"), false), Object);
 
     string short1(address1Hex, address1Hex+sizeof(address1Hex)-2); // last byte missing
-    BOOST_CHECK_THROW(addmultisig(createArgs(2, short1.c_str()), false), runtime_error);
+    BOOST_CHECK_THROW(addmultisig(createArgs(2, short1.c_str()), false), Object);
 
     string short2(address1Hex+2, address1Hex+sizeof(address1Hex)); // first byte missing
-    BOOST_CHECK_THROW(addmultisig(createArgs(2, short2.c_str()), false), runtime_error);
+    BOOST_CHECK_THROW(addmultisig(createArgs(2, short2.c_str()), false), Object);
 }
 
 // Run RPC tests over RPC...
@@ -104,7 +104,7 @@ BOOST_FIXTURE_TEST_CASE(rpc_scrapes, RPCServerFixture)
     string strValidPrivKey = "U9nhhCCbFfY64wozUZ6ScrNNvBqhGtoi8cNHXmaLm3wi1VHtjhr8";
     string strValidAddress2 = "PAjArWaTwv8P32b13iTn1bL7aN25Y9pMmJ";
 
-    // error: {"code":-1,"message":"Staking address must be in wallet."}
+    // error: {"code":-4,"message":"Staking address must be in wallet."}
     string strMethod = "setscrapeaddress";
     vector<string> strParams;
     strParams.push_back(strValidAddress);
@@ -114,7 +114,7 @@ BOOST_FIXTURE_TEST_CASE(rpc_scrapes, RPCServerFixture)
 
     int error_code;
     BOOST_CHECK(!readResponse(obj, error_code));
-    BOOST_CHECK_EQUAL(error_code, -1);
+    BOOST_CHECK_EQUAL(error_code, RPC_WALLET_ERROR);
 
     strMethod = "getscrapeaddress";
     strParams.clear();
@@ -123,14 +123,14 @@ BOOST_FIXTURE_TEST_CASE(rpc_scrapes, RPCServerFixture)
     obj = callRPC(strMethod, strParams);
 
     BOOST_CHECK(!readResponse(obj, error_code));
-    BOOST_CHECK_EQUAL(error_code, -1);
+    BOOST_CHECK_EQUAL(error_code, RPC_WALLET_ERROR);
 
     strMethod = "deletescrapeaddress";
 
     obj = callRPC(strMethod, strParams);
 
     BOOST_CHECK(!readResponse(obj, error_code));
-    BOOST_CHECK_EQUAL(error_code, -1);
+    BOOST_CHECK_EQUAL(error_code, RPC_WALLET_ERROR);
 
     // Import a valid private key for testing on.
     strMethod = "importprivkey";
@@ -151,7 +151,7 @@ BOOST_FIXTURE_TEST_CASE(rpc_scrapes, RPCServerFixture)
     obj = callRPC(strMethod, strParams);
 
     BOOST_CHECK(!readResponse(obj, error_code));
-    BOOST_CHECK_EQUAL(error_code, -5);
+    BOOST_CHECK_EQUAL(error_code, RPC_INVALID_ADDRESS_OR_KEY);
 
     strMethod = "getscrapeaddress";
     strParams.clear();
@@ -160,14 +160,14 @@ BOOST_FIXTURE_TEST_CASE(rpc_scrapes, RPCServerFixture)
     obj = callRPC(strMethod, strParams);
 
     BOOST_CHECK(!readResponse(obj, error_code));
-    BOOST_CHECK_EQUAL(error_code, -5);
+    BOOST_CHECK_EQUAL(error_code, RPC_INVALID_ADDRESS_OR_KEY);
 
     strMethod = "deletescrapeaddress";
 
     obj = callRPC(strMethod, strParams);
 
     BOOST_CHECK(!readResponse(obj, error_code));
-    BOOST_CHECK_EQUAL(error_code, -5);
+    BOOST_CHECK_EQUAL(error_code, RPC_INVALID_ADDRESS_OR_KEY);
 
     // error: {"code":-5,"message":"Invalid scrape address."}
     strMethod = "setscrapeaddress";
@@ -178,9 +178,9 @@ BOOST_FIXTURE_TEST_CASE(rpc_scrapes, RPCServerFixture)
     obj = callRPC(strMethod, strParams);
 
     BOOST_CHECK(!readResponse(obj, error_code));
-    BOOST_CHECK_EQUAL(error_code, -5);
+    BOOST_CHECK_EQUAL(error_code, RPC_INVALID_ADDRESS_OR_KEY);
 
-    // error: {"code":-1,"message":"Cannot set scrape address to the same as staking address."}
+    // error: {"code":-4,"message":"Cannot set scrape address to the same as staking address."}
     strParams.clear();
     strParams.push_back(strValidAddress);
     strParams.push_back(strValidAddress);
@@ -188,9 +188,9 @@ BOOST_FIXTURE_TEST_CASE(rpc_scrapes, RPCServerFixture)
     obj = callRPC(strMethod, strParams);
 
     BOOST_CHECK(!readResponse(obj, error_code));
-    BOOST_CHECK_EQUAL(error_code, -1);
+    BOOST_CHECK_EQUAL(error_code, RPC_WALLET_ERROR);
 
-    // error: ("code":-1,"message":"No scrape address set for address <staking address>")
+    // error: ("code":-4,"message":"No scrape address set for address <staking address>")
     strMethod = "getscrapeaddress";
     strParams.clear();
     strParams.push_back(strValidAddress);
@@ -198,14 +198,14 @@ BOOST_FIXTURE_TEST_CASE(rpc_scrapes, RPCServerFixture)
     obj = callRPC(strMethod, strParams);
 
     BOOST_CHECK(!readResponse(obj, error_code));
-    BOOST_CHECK_EQUAL(error_code, -1);
+    BOOST_CHECK_EQUAL(error_code, RPC_WALLET_ERROR);
 
     strMethod = "deletescrapeaddress";
 
     obj = callRPC(strMethod, strParams);
 
     BOOST_CHECK(!readResponse(obj, error_code));
-    BOOST_CHECK_EQUAL(error_code, -1);
+    BOOST_CHECK_EQUAL(error_code, RPC_WALLET_ERROR);
 
     // Valid setscrapeaddress
     strMethod = "setscrapeaddress";


### PR DESCRIPTION
Uses HTTP and RPC status codes from Bitcoin
Corrects inconsistencies between RPC error codes

There are a few instances instances where I was unsure whether the used error code was really valid so I commented it. In some cases error codes were changed because of inconsistencies or because of the use of the wrong error code in the first place.

This will need extensive review because of changed codes, unfortunately this may create issues for Paycoin RPC wallet implementations but should also bring some consistency between Paycoin and Bitcoin to better allow Bitcoin RPC software to work with Paycoin

(3 hours 30 minutes)